### PR TITLE
Added flag '-std=c++14' to CXX

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ def get_extensions():
 
     define_macros = []
 
-    extra_compile_args = {'cxx': ['-O3', '-g']}
+    extra_compile_args = {'cxx': ['-O3', '-g', '-std=c++14']}
     if (torch.cuda.is_available() and CUDA_HOME is not None) or os.getenv('FORCE_CUDA', '0') == '1':
         extension = CUDAExtension
         define_macros += [('WITH_CUDA', None)]


### PR DESCRIPTION
Without the flag I got this issue when running setup.py. 

```
(nightly) justanhduc@insight-SIM3:~/Downloads/nestedtensor$ python setup.py develop
Building wheel nestedtensor-0.0.1.dev20201102+1643992
running develop
running egg_info
creating nestedtensor.egg-info
writing nestedtensor.egg-info/PKG-INFO
writing dependency_links to nestedtensor.egg-info/dependency_links.txt
writing requirements to nestedtensor.egg-info/requires.txt
writing top-level names to nestedtensor.egg-info/top_level.txt
writing manifest file 'nestedtensor.egg-info/SOURCES.txt'
reading manifest file 'nestedtensor.egg-info/SOURCES.txt'
writing manifest file 'nestedtensor.egg-info/SOURCES.txt'
running build_ext
building 'nestedtensor._C' extension
creating build
creating build/temp.linux-x86_64-3.7
creating build/temp.linux-x86_64-3.7/home
creating build/temp.linux-x86_64-3.7/home/justanhduc
creating build/temp.linux-x86_64-3.7/home/justanhduc/Downloads
creating build/temp.linux-x86_64-3.7/home/justanhduc/Downloads/nestedtensor
creating build/temp.linux-x86_64-3.7/home/justanhduc/Downloads/nestedtensor/nestedtensor
creating build/temp.linux-x86_64-3.7/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc
gcc -pthread -B /home/justanhduc/anaconda3/envs/nightly/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DWITH_CUDA -I/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc -I/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include -I/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/api/include -I/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/TH -I/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/THC -I/home/justanhduc/cuda-10.1/include -I/home/justanhduc/anaconda3/envs/nightly/include/python3.7m -c /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp -o build/temp.linux-x86_64-3.7/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.o -O3 -g -DTORCH_API_INCLUDE_EXTENSION_H -DTORCH_EXTENSION_NAME=_C -D_GLIBCXX_USE_CXX11_ABI=0 -std=c++11
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/core/Device.h:5:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorBody.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/ivalue.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:3,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h: In function ‘torch::jit::Stack torch::jit::toTraceableStack(const pybind11::tuple&)’:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/Exception.h:355:20: warning: ‘void c10::detail::deprecated_AT_CHECK()’ is deprecated [-Wdeprecated-declarations]
     ::c10::detail::deprecated_AT_CHECK();                 \
                    ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:300:3: note: in expansion of macro ‘AT_CHECK’
   AT_CHECK(
   ^
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/core/Device.h:5:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorBody.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/ivalue.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:3,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/Exception.h:330:13: note: declared here
 inline void deprecated_AT_CHECK() {}
             ^
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/core/Device.h:5:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorBody.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/ivalue.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:3,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/Exception.h:355:20: warning: ‘void c10::detail::deprecated_AT_CHECK()’ is deprecated [-Wdeprecated-declarations]
     ::c10::detail::deprecated_AT_CHECK();                 \
                    ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:300:3: note: in expansion of macro ‘AT_CHECK’
   AT_CHECK(
   ^
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/core/Device.h:5:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorBody.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/ivalue.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:3,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/Exception.h:330:13: note: declared here
 inline void deprecated_AT_CHECK() {}
             ^
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/core/Device.h:5:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorBody.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/ivalue.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:3,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/Exception.h:355:40: warning: ‘void c10::detail::deprecated_AT_CHECK()’ is deprecated [-Wdeprecated-declarations]
     ::c10::detail::deprecated_AT_CHECK();                 \
                                        ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:300:3: note: in expansion of macro ‘AT_CHECK’
   AT_CHECK(
   ^
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/core/Device.h:5:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorBody.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/ivalue.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:3,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/Exception.h:330:13: note: declared here
 inline void deprecated_AT_CHECK() {}
             ^
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In member function ‘int64_t torch::nested_tensor::THPNestedTensor::element_size()’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:30:19: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
         _data, [](auto data) { return data.element_size(); });
                   ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In lambda function:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:30:44: error: request for member ‘element_size’ in ‘data’, which is of non-class type ‘int’
         _data, [](auto data) { return data.element_size(); });
                                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In member function ‘bool torch::nested_tensor::THPNestedTensor::requires_grad()’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:37:19: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
         _data, [](auto data) { return data.requires_grad(); });
                   ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In lambda function:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:37:44: error: request for member ‘requires_grad’ in ‘data’, which is of non-class type ‘int’
         _data, [](auto data) { return data.requires_grad(); });
                                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In member function ‘pybind11::object torch::nested_tensor::THPNestedTensor::nested_size()’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:44:19: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
         _data, [](auto data) { return data.nested_size(); }));
                   ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In lambda function:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:44:44: error: request for member ‘nested_size’ in ‘data’, which is of non-class type ‘int’
         _data, [](auto data) { return data.nested_size(); }));
                                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In member function ‘pybind11::object torch::nested_tensor::THPNestedTensor::nested_stride()’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:48:19: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
         _data, [](auto data) { return data.nested_stride(); }));
                   ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In lambda function:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:48:44: error: request for member ‘nested_stride’ in ‘data’, which is of non-class type ‘int’
         _data, [](auto data) { return data.nested_stride(); }));
                                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In member function ‘torch::nested_tensor::THPNestedTensor torch::nested_tensor::THPNestedTensor::requires_grad_(pybind11::bool_)’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:52:59: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
         data_map<THPNestedTensor>(_data, [&requires_grad](auto data) {
                                                           ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In lambda function:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:53:23: error: request for member ‘requires_grad_’ in ‘data’, which is of non-class type ‘int’
           return data.requires_grad_(requires_grad);
                       ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In member function ‘torch::nested_tensor::THPNestedTensor torch::nested_tensor::THPNestedTensor::requires_grad_(pybind11::bool_)’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:52:57: warning: ‘torch::nested_tensor::THPNestedTensor::requires_grad_(pybind11::bool_)::<lambda(int)>’ declared with greater visibility than the type of its field ‘torch::nested_tensor::THPNestedTensor::requires_grad_(pybind11::bool_)::<lambda(int)>::<requires_grad capture>’ [-Wattributes]
         data_map<THPNestedTensor>(_data, [&requires_grad](auto data) {
                                                         ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In member function ‘torch::nested_tensor::THPNestedTensor torch::nested_tensor::THPNestedTensor::grad()’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:58:19: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
         _data, [](auto data) { return THPNestedTensor(data.grad()); });
                   ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In lambda function:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:58:60: error: request for member ‘grad’ in ‘data’, which is of non-class type ‘int’
         _data, [](auto data) { return THPNestedTensor(data.grad()); });
                                                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In member function ‘torch::nested_tensor::THPNestedTensor torch::nested_tensor::THPNestedTensor::detach()’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:62:19: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
         _data, [](auto data) { return THPNestedTensor(data.detach()); });
                   ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In lambda function:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:62:60: error: request for member ‘detach’ in ‘data’, which is of non-class type ‘int’
         _data, [](auto data) { return THPNestedTensor(data.detach()); });
                                                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In member function ‘torch::nested_tensor::THPNestedTensor torch::nested_tensor::THPNestedTensor::pin_memory()’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:66:19: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
         _data, [](auto data) { return THPNestedTensor(data.pin_memory()); });
                   ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In lambda function:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:66:60: error: request for member ‘pin_memory’ in ‘data’, which is of non-class type ‘int’
         _data, [](auto data) { return THPNestedTensor(data.pin_memory()); });
                                                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In member function ‘std::string torch::nested_tensor::THPNestedTensor::str()’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:69:44: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
     return data_map<std::string>(_data, [](auto data) {
                                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In lambda function:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:70:39: error: request for member ‘get_structure’ in ‘data’, which is of non-class type ‘int’
       return _NestedNode___str__(data.get_structure());
                                       ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In member function ‘int64_t torch::nested_tensor::THPNestedTensor::len()’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:74:40: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
     return data_map<int64_t>(_data, [](auto data) { return data.__len__(); });
                                        ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In lambda function:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:74:65: error: request for member ‘__len__’ in ‘data’, which is of non-class type ‘int’
     return data_map<int64_t>(_data, [](auto data) { return data.__len__(); });
                                                                 ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In member function ‘bool torch::nested_tensor::THPNestedTensor::is_pinned()’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:77:37: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
     return data_map<bool>(_data, [](auto data) { return data.is_pinned(); });
                                     ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In lambda function:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:77:62: error: request for member ‘is_pinned’ in ‘data’, which is of non-class type ‘int’
     return data_map<bool>(_data, [](auto data) { return data.is_pinned(); });
                                                              ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In member function ‘int64_t torch::nested_tensor::THPNestedTensor::nested_dim()’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:81:19: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
         _data, [](auto data) { return data.nested_dim(); });
                   ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In lambda function:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:81:44: error: request for member ‘nested_dim’ in ‘data’, which is of non-class type ‘int’
         _data, [](auto data) { return data.nested_dim(); });
                                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In member function ‘int64_t torch::nested_tensor::THPNestedTensor::dim()’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:84:40: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
     return data_map<int64_t>(_data, [](auto data) { return data.dim(); });
                                        ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In lambda function:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:84:65: error: request for member ‘dim’ in ‘data’, which is of non-class type ‘int’
     return data_map<int64_t>(_data, [](auto data) { return data.dim(); });
                                                                 ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In member function ‘int64_t torch::nested_tensor::THPNestedTensor::numel()’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:87:40: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
     return data_map<int64_t>(_data, [](auto data) { return data.numel(); });
                                        ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In lambda function:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:87:65: error: request for member ‘numel’ in ‘data’, which is of non-class type ‘int’
     return data_map<int64_t>(_data, [](auto data) { return data.numel(); });
                                                                 ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In member function ‘at::Tensor torch::nested_tensor::THPNestedTensor::to_tensor()’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:91:19: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
         _data, [](auto data) { return data.to_tensor(); });
                   ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In lambda function:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:91:44: error: request for member ‘to_tensor’ in ‘data’, which is of non-class type ‘int’
         _data, [](auto data) { return data.to_tensor(); });
                                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In member function ‘bool torch::nested_tensor::THPNestedTensor::is_contiguous()’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:95:19: error: use of ‘auto’ in lambda parameter declaration only available with -std=c++14 or -std=gnu++14
         _data, [](auto data) { return data.is_contiguous(); });
                   ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h: In lambda function:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:95:44: error: request for member ‘is_contiguous’ in ‘data’, which is of non-class type ‘int’
         _data, [](auto data) { return data.is_contiguous(); });
                                            ^
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h: In instantiation of ‘Result c10::either<Left, Right>::map(LeftMapFunc&&, RightMapFunc&&) const [with Result = long int; LeftMapFunc = torch::nested_tensor::THPNestedTensor::element_size()::<lambda(int)>&; RightMapFunc = torch::nested_tensor::THPNestedTensor::element_size()::<lambda(int)>&; Left = torch::nested_tensor::_ListNestedTensor; Right = torch::nested_tensor::_BufferNestedTensor]’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:18:33:   required from ‘Result torch::nested_tensor::data_map(c10::either<torch::nested_tensor::_ListNestedTensor, torch::nested_tensor::_BufferNestedTensor>&, F) [with Result = long int; F = torch::nested_tensor::THPNestedTensor::element_size()::<lambda(int)>]’
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:30:61:   required from here
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::element_size()::<lambda(int)>) (const torch::nested_tensor::_ListNestedTensor&)’
       return std::forward<LeftMapFunc>(leftMapFunc)(_left);
                                                    ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:30:28: note: candidate: torch::nested_tensor::THPNestedTensor::element_size()::<lambda(int)>
         _data, [](auto data) { return data.element_size(); });
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:30:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_ListNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::element_size()::<lambda(int)>) (const torch::nested_tensor::_BufferNestedTensor&)’
       return std::forward<RightMapFunc>(rightMapFunc)(_right);
                                                      ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:30:28: note: candidate: torch::nested_tensor::THPNestedTensor::element_size()::<lambda(int)>
         _data, [](auto data) { return data.element_size(); });
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:30:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_BufferNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h: In instantiation of ‘Result c10::either<Left, Right>::map(LeftMapFunc&&, RightMapFunc&&) const [with Result = bool; LeftMapFunc = torch::nested_tensor::THPNestedTensor::requires_grad()::<lambda(int)>&; RightMapFunc = torch::nested_tensor::THPNestedTensor::requires_grad()::<lambda(int)>&; Left = torch::nested_tensor::_ListNestedTensor; Right = torch::nested_tensor::_BufferNestedTensor]’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:18:33:   required from ‘Result torch::nested_tensor::data_map(c10::either<torch::nested_tensor::_ListNestedTensor, torch::nested_tensor::_BufferNestedTensor>&, F) [with Result = bool; F = torch::nested_tensor::THPNestedTensor::requires_grad()::<lambda(int)>]’
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:37:62:   required from here
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::requires_grad()::<lambda(int)>) (const torch::nested_tensor::_ListNestedTensor&)’
       return std::forward<LeftMapFunc>(leftMapFunc)(_left);
                                                    ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:37:28: note: candidate: torch::nested_tensor::THPNestedTensor::requires_grad()::<lambda(int)>
         _data, [](auto data) { return data.requires_grad(); });
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:37:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_ListNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::requires_grad()::<lambda(int)>) (const torch::nested_tensor::_BufferNestedTensor&)’
       return std::forward<RightMapFunc>(rightMapFunc)(_right);
                                                      ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:37:28: note: candidate: torch::nested_tensor::THPNestedTensor::requires_grad()::<lambda(int)>
         _data, [](auto data) { return data.requires_grad(); });
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:37:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_BufferNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h: In instantiation of ‘Result c10::either<Left, Right>::map(LeftMapFunc&&, RightMapFunc&&) const [with Result = torch::nested_tensor::NestedNode<c10::List<long int> >; LeftMapFunc = torch::nested_tensor::THPNestedTensor::nested_size()::<lambda(int)>&; RightMapFunc = torch::nested_tensor::THPNestedTensor::nested_size()::<lambda(int)>&; Left = torch::nested_tensor::_ListNestedTensor; Right = torch::nested_tensor::_BufferNestedTensor]’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:18:33:   required from ‘Result torch::nested_tensor::data_map(c10::either<torch::nested_tensor::_ListNestedTensor, torch::nested_tensor::_BufferNestedTensor>&, F) [with Result = torch::nested_tensor::NestedNode<c10::List<long int> >; F = torch::nested_tensor::THPNestedTensor::nested_size()::<lambda(int)>]’
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:44:60:   required from here
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::nested_size()::<lambda(int)>) (const torch::nested_tensor::_ListNestedTensor&)’
       return std::forward<LeftMapFunc>(leftMapFunc)(_left);
                                                    ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:44:28: note: candidate: torch::nested_tensor::THPNestedTensor::nested_size()::<lambda(int)>
         _data, [](auto data) { return data.nested_size(); }));
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:44:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_ListNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::nested_size()::<lambda(int)>) (const torch::nested_tensor::_BufferNestedTensor&)’
       return std::forward<RightMapFunc>(rightMapFunc)(_right);
                                                      ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:44:28: note: candidate: torch::nested_tensor::THPNestedTensor::nested_size()::<lambda(int)>
         _data, [](auto data) { return data.nested_size(); }));
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:44:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_BufferNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h: In instantiation of ‘Result c10::either<Left, Right>::map(LeftMapFunc&&, RightMapFunc&&) const [with Result = torch::nested_tensor::NestedNode<c10::List<long int> >; LeftMapFunc = torch::nested_tensor::THPNestedTensor::nested_stride()::<lambda(int)>&; RightMapFunc = torch::nested_tensor::THPNestedTensor::nested_stride()::<lambda(int)>&; Left = torch::nested_tensor::_ListNestedTensor; Right = torch::nested_tensor::_BufferNestedTensor]’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:18:33:   required from ‘Result torch::nested_tensor::data_map(c10::either<torch::nested_tensor::_ListNestedTensor, torch::nested_tensor::_BufferNestedTensor>&, F) [with Result = torch::nested_tensor::NestedNode<c10::List<long int> >; F = torch::nested_tensor::THPNestedTensor::nested_stride()::<lambda(int)>]’
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:48:62:   required from here
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::nested_stride()::<lambda(int)>) (const torch::nested_tensor::_ListNestedTensor&)’
       return std::forward<LeftMapFunc>(leftMapFunc)(_left);
                                                    ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:48:28: note: candidate: torch::nested_tensor::THPNestedTensor::nested_stride()::<lambda(int)>
         _data, [](auto data) { return data.nested_stride(); }));
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:48:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_ListNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::nested_stride()::<lambda(int)>) (const torch::nested_tensor::_BufferNestedTensor&)’
       return std::forward<RightMapFunc>(rightMapFunc)(_right);
                                                      ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:48:28: note: candidate: torch::nested_tensor::THPNestedTensor::nested_stride()::<lambda(int)>
         _data, [](auto data) { return data.nested_stride(); }));
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:48:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_BufferNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h: In instantiation of ‘Result c10::either<Left, Right>::map(LeftMapFunc&&, RightMapFunc&&) const [with Result = torch::nested_tensor::THPNestedTensor; LeftMapFunc = torch::nested_tensor::THPNestedTensor::requires_grad_(pybind11::bool_)::<lambda(int)>&; RightMapFunc = torch::nested_tensor::THPNestedTensor::requires_grad_(pybind11::bool_)::<lambda(int)>&; Left = torch::nested_tensor::_ListNestedTensor; Right = torch::nested_tensor::_BufferNestedTensor]’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:18:33:   required from ‘Result torch::nested_tensor::data_map(c10::either<torch::nested_tensor::_ListNestedTensor, torch::nested_tensor::_BufferNestedTensor>&, F) [with Result = torch::nested_tensor::THPNestedTensor; F = torch::nested_tensor::THPNestedTensor::requires_grad_(pybind11::bool_)::<lambda(int)>]’
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:54:10:   required from here
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::requires_grad_(pybind11::bool_)::<lambda(int)>) (const torch::nested_tensor::_ListNestedTensor&)’
       return std::forward<LeftMapFunc>(leftMapFunc)(_left);
                                                    ^
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:52:68: note: candidate: torch::nested_tensor::THPNestedTensor::requires_grad_(pybind11::bool_)::<lambda(int)>
         data_map<THPNestedTensor>(_data, [&requires_grad](auto data) {
                                                                    ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:52:68: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_ListNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::requires_grad_(pybind11::bool_)::<lambda(int)>) (const torch::nested_tensor::_BufferNestedTensor&)’
       return std::forward<RightMapFunc>(rightMapFunc)(_right);
                                                      ^
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:52:68: note: candidate: torch::nested_tensor::THPNestedTensor::requires_grad_(pybind11::bool_)::<lambda(int)>
         data_map<THPNestedTensor>(_data, [&requires_grad](auto data) {
                                                                    ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:52:68: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_BufferNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h: In instantiation of ‘Result c10::either<Left, Right>::map(LeftMapFunc&&, RightMapFunc&&) const [with Result = torch::nested_tensor::THPNestedTensor; LeftMapFunc = torch::nested_tensor::THPNestedTensor::grad()::<lambda(int)>&; RightMapFunc = torch::nested_tensor::THPNestedTensor::grad()::<lambda(int)>&; Left = torch::nested_tensor::_ListNestedTensor; Right = torch::nested_tensor::_BufferNestedTensor]’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:18:33:   required from ‘Result torch::nested_tensor::data_map(c10::either<torch::nested_tensor::_ListNestedTensor, torch::nested_tensor::_BufferNestedTensor>&, F) [with Result = torch::nested_tensor::THPNestedTensor; F = torch::nested_tensor::THPNestedTensor::grad()::<lambda(int)>]’
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:58:70:   required from here
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::grad()::<lambda(int)>) (const torch::nested_tensor::_ListNestedTensor&)’
       return std::forward<LeftMapFunc>(leftMapFunc)(_left);
                                                    ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:58:28: note: candidate: torch::nested_tensor::THPNestedTensor::grad()::<lambda(int)>
         _data, [](auto data) { return THPNestedTensor(data.grad()); });
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:58:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_ListNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::grad()::<lambda(int)>) (const torch::nested_tensor::_BufferNestedTensor&)’
       return std::forward<RightMapFunc>(rightMapFunc)(_right);
                                                      ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:58:28: note: candidate: torch::nested_tensor::THPNestedTensor::grad()::<lambda(int)>
         _data, [](auto data) { return THPNestedTensor(data.grad()); });
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:58:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_BufferNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h: In instantiation of ‘Result c10::either<Left, Right>::map(LeftMapFunc&&, RightMapFunc&&) const [with Result = torch::nested_tensor::THPNestedTensor; LeftMapFunc = torch::nested_tensor::THPNestedTensor::detach()::<lambda(int)>&; RightMapFunc = torch::nested_tensor::THPNestedTensor::detach()::<lambda(int)>&; Left = torch::nested_tensor::_ListNestedTensor; Right = torch::nested_tensor::_BufferNestedTensor]’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:18:33:   required from ‘Result torch::nested_tensor::data_map(c10::either<torch::nested_tensor::_ListNestedTensor, torch::nested_tensor::_BufferNestedTensor>&, F) [with Result = torch::nested_tensor::THPNestedTensor; F = torch::nested_tensor::THPNestedTensor::detach()::<lambda(int)>]’
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:62:72:   required from here
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::detach()::<lambda(int)>) (const torch::nested_tensor::_ListNestedTensor&)’
       return std::forward<LeftMapFunc>(leftMapFunc)(_left);
                                                    ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:62:28: note: candidate: torch::nested_tensor::THPNestedTensor::detach()::<lambda(int)>
         _data, [](auto data) { return THPNestedTensor(data.detach()); });
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:62:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_ListNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::detach()::<lambda(int)>) (const torch::nested_tensor::_BufferNestedTensor&)’
       return std::forward<RightMapFunc>(rightMapFunc)(_right);
                                                      ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:62:28: note: candidate: torch::nested_tensor::THPNestedTensor::detach()::<lambda(int)>
         _data, [](auto data) { return THPNestedTensor(data.detach()); });
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:62:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_BufferNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h: In instantiation of ‘Result c10::either<Left, Right>::map(LeftMapFunc&&, RightMapFunc&&) const [with Result = torch::nested_tensor::THPNestedTensor; LeftMapFunc = torch::nested_tensor::THPNestedTensor::pin_memory()::<lambda(int)>&; RightMapFunc = torch::nested_tensor::THPNestedTensor::pin_memory()::<lambda(int)>&; Left = torch::nested_tensor::_ListNestedTensor; Right = torch::nested_tensor::_BufferNestedTensor]’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:18:33:   required from ‘Result torch::nested_tensor::data_map(c10::either<torch::nested_tensor::_ListNestedTensor, torch::nested_tensor::_BufferNestedTensor>&, F) [with Result = torch::nested_tensor::THPNestedTensor; F = torch::nested_tensor::THPNestedTensor::pin_memory()::<lambda(int)>]’
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:66:76:   required from here
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::pin_memory()::<lambda(int)>) (const torch::nested_tensor::_ListNestedTensor&)’
       return std::forward<LeftMapFunc>(leftMapFunc)(_left);
                                                    ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:66:28: note: candidate: torch::nested_tensor::THPNestedTensor::pin_memory()::<lambda(int)>
         _data, [](auto data) { return THPNestedTensor(data.pin_memory()); });
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:66:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_ListNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::pin_memory()::<lambda(int)>) (const torch::nested_tensor::_BufferNestedTensor&)’
       return std::forward<RightMapFunc>(rightMapFunc)(_right);
                                                      ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:66:28: note: candidate: torch::nested_tensor::THPNestedTensor::pin_memory()::<lambda(int)>
         _data, [](auto data) { return THPNestedTensor(data.pin_memory()); });
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:66:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_BufferNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h: In instantiation of ‘Result c10::either<Left, Right>::map(LeftMapFunc&&, RightMapFunc&&) const [with Result = std::basic_string<char>; LeftMapFunc = torch::nested_tensor::THPNestedTensor::str()::<lambda(int)>&; RightMapFunc = torch::nested_tensor::THPNestedTensor::str()::<lambda(int)>&; Left = torch::nested_tensor::_ListNestedTensor; Right = torch::nested_tensor::_BufferNestedTensor]’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:18:33:   required from ‘Result torch::nested_tensor::data_map(c10::either<torch::nested_tensor::_ListNestedTensor, torch::nested_tensor::_BufferNestedTensor>&, F) [with Result = std::basic_string<char>; F = torch::nested_tensor::THPNestedTensor::str()::<lambda(int)>]’
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:71:6:   required from here
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::str()::<lambda(int)>) (const torch::nested_tensor::_ListNestedTensor&)’
       return std::forward<LeftMapFunc>(leftMapFunc)(_left);
                                                    ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:69:53: note: candidate: torch::nested_tensor::THPNestedTensor::str()::<lambda(int)>
     return data_map<std::string>(_data, [](auto data) {
                                                     ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:69:53: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_ListNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::str()::<lambda(int)>) (const torch::nested_tensor::_BufferNestedTensor&)’
       return std::forward<RightMapFunc>(rightMapFunc)(_right);
                                                      ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:69:53: note: candidate: torch::nested_tensor::THPNestedTensor::str()::<lambda(int)>
     return data_map<std::string>(_data, [](auto data) {
                                                     ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:69:53: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_BufferNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h: In instantiation of ‘Result c10::either<Left, Right>::map(LeftMapFunc&&, RightMapFunc&&) const [with Result = long int; LeftMapFunc = torch::nested_tensor::THPNestedTensor::len()::<lambda(int)>&; RightMapFunc = torch::nested_tensor::THPNestedTensor::len()::<lambda(int)>&; Left = torch::nested_tensor::_ListNestedTensor; Right = torch::nested_tensor::_BufferNestedTensor]’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:18:33:   required from ‘Result torch::nested_tensor::data_map(c10::either<torch::nested_tensor::_ListNestedTensor, torch::nested_tensor::_BufferNestedTensor>&, F) [with Result = long int; F = torch::nested_tensor::THPNestedTensor::len()::<lambda(int)>]’
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:74:77:   required from here
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::len()::<lambda(int)>) (const torch::nested_tensor::_ListNestedTensor&)’
       return std::forward<LeftMapFunc>(leftMapFunc)(_left);
                                                    ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:74:49: note: candidate: torch::nested_tensor::THPNestedTensor::len()::<lambda(int)>
     return data_map<int64_t>(_data, [](auto data) { return data.__len__(); });
                                                 ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:74:49: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_ListNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::len()::<lambda(int)>) (const torch::nested_tensor::_BufferNestedTensor&)’
       return std::forward<RightMapFunc>(rightMapFunc)(_right);
                                                      ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:74:49: note: candidate: torch::nested_tensor::THPNestedTensor::len()::<lambda(int)>
     return data_map<int64_t>(_data, [](auto data) { return data.__len__(); });
                                                 ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:74:49: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_BufferNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h: In instantiation of ‘Result c10::either<Left, Right>::map(LeftMapFunc&&, RightMapFunc&&) const [with Result = bool; LeftMapFunc = torch::nested_tensor::THPNestedTensor::is_pinned()::<lambda(int)>&; RightMapFunc = torch::nested_tensor::THPNestedTensor::is_pinned()::<lambda(int)>&; Left = torch::nested_tensor::_ListNestedTensor; Right = torch::nested_tensor::_BufferNestedTensor]’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:18:33:   required from ‘Result torch::nested_tensor::data_map(c10::either<torch::nested_tensor::_ListNestedTensor, torch::nested_tensor::_BufferNestedTensor>&, F) [with Result = bool; F = torch::nested_tensor::THPNestedTensor::is_pinned()::<lambda(int)>]’
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:77:76:   required from here
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::is_pinned()::<lambda(int)>) (const torch::nested_tensor::_ListNestedTensor&)’
       return std::forward<LeftMapFunc>(leftMapFunc)(_left);
                                                    ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:77:46: note: candidate: torch::nested_tensor::THPNestedTensor::is_pinned()::<lambda(int)>
     return data_map<bool>(_data, [](auto data) { return data.is_pinned(); });
                                              ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:77:46: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_ListNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::is_pinned()::<lambda(int)>) (const torch::nested_tensor::_BufferNestedTensor&)’
       return std::forward<RightMapFunc>(rightMapFunc)(_right);
                                                      ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:77:46: note: candidate: torch::nested_tensor::THPNestedTensor::is_pinned()::<lambda(int)>
     return data_map<bool>(_data, [](auto data) { return data.is_pinned(); });
                                              ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:77:46: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_BufferNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h: In instantiation of ‘Result c10::either<Left, Right>::map(LeftMapFunc&&, RightMapFunc&&) const [with Result = long int; LeftMapFunc = torch::nested_tensor::THPNestedTensor::nested_dim()::<lambda(int)>&; RightMapFunc = torch::nested_tensor::THPNestedTensor::nested_dim()::<lambda(int)>&; Left = torch::nested_tensor::_ListNestedTensor; Right = torch::nested_tensor::_BufferNestedTensor]’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:18:33:   required from ‘Result torch::nested_tensor::data_map(c10::either<torch::nested_tensor::_ListNestedTensor, torch::nested_tensor::_BufferNestedTensor>&, F) [with Result = long int; F = torch::nested_tensor::THPNestedTensor::nested_dim()::<lambda(int)>]’
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:81:59:   required from here
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::nested_dim()::<lambda(int)>) (const torch::nested_tensor::_ListNestedTensor&)’
       return std::forward<LeftMapFunc>(leftMapFunc)(_left);
                                                    ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:81:28: note: candidate: torch::nested_tensor::THPNestedTensor::nested_dim()::<lambda(int)>
         _data, [](auto data) { return data.nested_dim(); });
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:81:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_ListNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::nested_dim()::<lambda(int)>) (const torch::nested_tensor::_BufferNestedTensor&)’
       return std::forward<RightMapFunc>(rightMapFunc)(_right);
                                                      ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:81:28: note: candidate: torch::nested_tensor::THPNestedTensor::nested_dim()::<lambda(int)>
         _data, [](auto data) { return data.nested_dim(); });
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:81:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_BufferNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h: In instantiation of ‘Result c10::either<Left, Right>::map(LeftMapFunc&&, RightMapFunc&&) const [with Result = long int; LeftMapFunc = torch::nested_tensor::THPNestedTensor::dim()::<lambda(int)>&; RightMapFunc = torch::nested_tensor::THPNestedTensor::dim()::<lambda(int)>&; Left = torch::nested_tensor::_ListNestedTensor; Right = torch::nested_tensor::_BufferNestedTensor]’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:18:33:   required from ‘Result torch::nested_tensor::data_map(c10::either<torch::nested_tensor::_ListNestedTensor, torch::nested_tensor::_BufferNestedTensor>&, F) [with Result = long int; F = torch::nested_tensor::THPNestedTensor::dim()::<lambda(int)>]’
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:84:73:   required from here
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::dim()::<lambda(int)>) (const torch::nested_tensor::_ListNestedTensor&)’
       return std::forward<LeftMapFunc>(leftMapFunc)(_left);
                                                    ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:84:49: note: candidate: torch::nested_tensor::THPNestedTensor::dim()::<lambda(int)>
     return data_map<int64_t>(_data, [](auto data) { return data.dim(); });
                                                 ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:84:49: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_ListNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::dim()::<lambda(int)>) (const torch::nested_tensor::_BufferNestedTensor&)’
       return std::forward<RightMapFunc>(rightMapFunc)(_right);
                                                      ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:84:49: note: candidate: torch::nested_tensor::THPNestedTensor::dim()::<lambda(int)>
     return data_map<int64_t>(_data, [](auto data) { return data.dim(); });
                                                 ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:84:49: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_BufferNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h: In instantiation of ‘Result c10::either<Left, Right>::map(LeftMapFunc&&, RightMapFunc&&) const [with Result = long int; LeftMapFunc = torch::nested_tensor::THPNestedTensor::numel()::<lambda(int)>&; RightMapFunc = torch::nested_tensor::THPNestedTensor::numel()::<lambda(int)>&; Left = torch::nested_tensor::_ListNestedTensor; Right = torch::nested_tensor::_BufferNestedTensor]’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:18:33:   required from ‘Result torch::nested_tensor::data_map(c10::either<torch::nested_tensor::_ListNestedTensor, torch::nested_tensor::_BufferNestedTensor>&, F) [with Result = long int; F = torch::nested_tensor::THPNestedTensor::numel()::<lambda(int)>]’
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:87:75:   required from here
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::numel()::<lambda(int)>) (const torch::nested_tensor::_ListNestedTensor&)’
       return std::forward<LeftMapFunc>(leftMapFunc)(_left);
                                                    ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:87:49: note: candidate: torch::nested_tensor::THPNestedTensor::numel()::<lambda(int)>
     return data_map<int64_t>(_data, [](auto data) { return data.numel(); });
                                                 ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:87:49: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_ListNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::numel()::<lambda(int)>) (const torch::nested_tensor::_BufferNestedTensor&)’
       return std::forward<RightMapFunc>(rightMapFunc)(_right);
                                                      ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:87:49: note: candidate: torch::nested_tensor::THPNestedTensor::numel()::<lambda(int)>
     return data_map<int64_t>(_data, [](auto data) { return data.numel(); });
                                                 ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:87:49: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_BufferNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h: In instantiation of ‘Result c10::either<Left, Right>::map(LeftMapFunc&&, RightMapFunc&&) const [with Result = at::Tensor; LeftMapFunc = torch::nested_tensor::THPNestedTensor::to_tensor()::<lambda(int)>&; RightMapFunc = torch::nested_tensor::THPNestedTensor::to_tensor()::<lambda(int)>&; Left = torch::nested_tensor::_ListNestedTensor; Right = torch::nested_tensor::_BufferNestedTensor]’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:18:33:   required from ‘Result torch::nested_tensor::data_map(c10::either<torch::nested_tensor::_ListNestedTensor, torch::nested_tensor::_BufferNestedTensor>&, F) [with Result = at::Tensor; F = torch::nested_tensor::THPNestedTensor::to_tensor()::<lambda(int)>]’
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:91:58:   required from here
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::to_tensor()::<lambda(int)>) (const torch::nested_tensor::_ListNestedTensor&)’
       return std::forward<LeftMapFunc>(leftMapFunc)(_left);
                                                    ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:91:28: note: candidate: torch::nested_tensor::THPNestedTensor::to_tensor()::<lambda(int)>
         _data, [](auto data) { return data.to_tensor(); });
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:91:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_ListNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::to_tensor()::<lambda(int)>) (const torch::nested_tensor::_BufferNestedTensor&)’
       return std::forward<RightMapFunc>(rightMapFunc)(_right);
                                                      ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:91:28: note: candidate: torch::nested_tensor::THPNestedTensor::to_tensor()::<lambda(int)>
         _data, [](auto data) { return data.to_tensor(); });
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:91:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_BufferNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h: In instantiation of ‘Result c10::either<Left, Right>::map(LeftMapFunc&&, RightMapFunc&&) const [with Result = bool; LeftMapFunc = torch::nested_tensor::THPNestedTensor::is_contiguous()::<lambda(int)>&; RightMapFunc = torch::nested_tensor::THPNestedTensor::is_contiguous()::<lambda(int)>&; Left = torch::nested_tensor::_ListNestedTensor; Right = torch::nested_tensor::_BufferNestedTensor]’:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:18:33:   required from ‘Result torch::nested_tensor::data_map(c10::either<torch::nested_tensor::_ListNestedTensor, torch::nested_tensor::_BufferNestedTensor>&, F) [with Result = bool; F = torch::nested_tensor::THPNestedTensor::is_contiguous()::<lambda(int)>]’
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:95:62:   required from here
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::is_contiguous()::<lambda(int)>) (const torch::nested_tensor::_ListNestedTensor&)’
       return std::forward<LeftMapFunc>(leftMapFunc)(_left);
                                                    ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:136:52: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:95:28: note: candidate: torch::nested_tensor::THPNestedTensor::is_contiguous()::<lambda(int)>
         _data, [](auto data) { return data.is_contiguous(); });
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:95:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_ListNestedTensor’ to ‘int’
In file included from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/DispatchTable.h:7:0,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/OperatorEntry.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/dispatch/Dispatcher.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/core/TensorMethods.h:10,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Tensor.h:12,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/Context.h:4,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/ATen/ATen.h:5,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/Dtype.h:3,
                 from /home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/torch/csrc/jit/pybind_utils.h:7,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/nested_node.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/buffer_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: error: no match for call to ‘(torch::nested_tensor::THPNestedTensor::is_contiguous()::<lambda(int)>) (const torch::nested_tensor::_BufferNestedTensor&)’
       return std::forward<RightMapFunc>(rightMapFunc)(_right);
                                                      ^
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note: candidate: void (*)(int) <conversion>
/home/justanhduc/anaconda3/envs/nightly/lib/python3.7/site-packages/torch/include/c10/util/either.h:138:54: note:   candidate expects 2 arguments, 2 provided
In file included from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/creation.h:2:0,
                 from /home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/py_init.cpp:1:
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:95:28: note: candidate: torch::nested_tensor::THPNestedTensor::is_contiguous()::<lambda(int)>
         _data, [](auto data) { return data.is_contiguous(); });
                            ^
/home/justanhduc/Downloads/nestedtensor/nestedtensor/csrc/python_nested_tensor.h:95:28: note:   no known conversion for argument 1 from ‘const torch::nested_tensor::_BufferNestedTensor’ to ‘int’
error: command 'gcc' failed with exit status 1

```