### PR TITLE
Added basic test coverage for nested tensor masking

### DIFF
--- a/nestedtensor/nested/masking.py
+++ b/nestedtensor/nested/masking.py
@@ -14,13 +14,13 @@ def nested_tensor_from_padded_tensor(tensor, nested_dim=None, padding=-1):
     mask = (tensor != padding)
     return nested_tensor_from_tensor_mask(tensor, mask, nested_dim)
 
+"""
+Given a tensor t of size N_1 x N_2 x ... N_n and mask m of size M_1 x M_2 x ... M_d where d <= n
+return a NestedTensor of dimensionality d where subtensor t[i_1][i_2]...[i_d] is included as a Tensor constituent if m[i_1][i_2]...[i_d].
+The resulting NestedTensor will be of dimension n.
+Unless specific, it is attempted to yield a NestedTensor of minimal nested dimension.
+"""
 def nested_tensor_from_tensor_mask(tensor, mask, nested_dim=None):
-    """
-    Given a tensor t of size N_1 x N_2 x ... N_n and mask m of size M_1 x M_2 x ... M_d where d <= n
-    return a NestedTensor of dimensionality d where subtensor t[i_1][i_2]...[i_d] is included as a Tensor constituent if m[i_1][i_2]...[i_d].
-    The resulting NestedTensor will be of dimension n.
-    Unless specific, it is attempted to yield a NestedTensor of minimal nested dimension.
-    """
     # TODO: Should be possible with views only.
     if not mask.dim() > 0:
         raise RuntimeError("Mask has to have dimention > 0")
@@ -44,6 +44,9 @@ def nested_tensor_from_tensor_mask(tensor, mask, nested_dim=None):
             return torch.stack(tensors)
         else:
             return creation.nested_tensor(tensors)
+
+    if nested_dim is not None and mask.dim() < nested_dim:
+        raise ValueError("Mask dimension ({0}) is too small to construct nested tensor with nested dimension of {1}".format(mask.dim(), nested_dim))
 
     if mask.dim() == 1:
         tensors = [tensor[i] if mask[i]

--- a/nestedtensor/nested/masking.py
+++ b/nestedtensor/nested/masking.py
@@ -22,7 +22,8 @@ def nested_tensor_from_tensor_mask(tensor, mask, nested_dim=None):
     Unless specific, it is attempted to yield a NestedTensor of minimal nested dimension.
     """
     # TODO: Should be possible with views only.
-    assert mask.dim() > 0
+    if not mask.dim() > 0:
+        raise RuntimeError("Mask has to have dimention > 0")
 
     # TODO: Need to define empty-list and 0 numel semantics
     # TODO: Test edge-cases and kwargs

--- a/nestedtensor/nested/masking.py
+++ b/nestedtensor/nested/masking.py
@@ -99,9 +99,9 @@ def tensor_list(lst):
 
 
 def make_tensor_mask(tensor_lst, mask_dim):
-    tensormask = tensor_list(tensor_lst)
-    tensormask = merge_tensor_mask(tensormask, mask_dim)
-    return tensormask.tensor, tensormask.mask
+    tensor_mask = tensor_list(tensor_lst)
+    tensor_mask = merge_tensor_mask(tensor_mask, mask_dim)
+    return tensor_mask.tensor, tensor_mask.mask
 
 
 def pad_tensor_to_shape(t, goal_shape):

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,6 +1,5 @@
-__version__ = '0.0.1.dev20201306+60112ae'
-git_version = '60112aea90cc54c98e5997bee9166ef94ee0e114'
-
+__version__ = '0.0.1.dev202013016+9bb2a43'
+git_version = '9bb2a4381f5ed33ec94955dd89330dfdf9e545ce'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,6 @@
 __version__ = '0.0.1.dev20201306+60112ae'
 git_version = '60112aea90cc54c98e5997bee9166ef94ee0e114'
+
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/test/test_nested_tensor_masking.py
+++ b/test/test_nested_tensor_masking.py
@@ -3,94 +3,132 @@ import functools
 import pdb
 import sys
 import torch
-import nestedtensor as NT
+import nestedtensor as nt
 import unittest
 from utils import TestCase
 import random
-
 import utils
+
+#
+# Test data
+#
+original_nt = nt.nested_tensor([
+    nt.nested_tensor([
+        nt.nested_tensor([
+            torch.tensor([[1, 2], 
+                           [3, 4]])
+        ]),
+     ]),
+    nt.nested_tensor([
+        nt.nested_tensor([
+            torch.tensor([[5, 6],
+                          [7, 8]])
+        ]),
+    ])
+])
+
+original_nt2 = nt.nested_tensor([
+    nt.nested_tensor([
+        nt.nested_tensor([
+            torch.tensor([1, 2])
+        ]),
+    ]),
+    nt.nested_tensor([
+        nt.nested_tensor([
+            torch.tensor([3, 4]),
+            torch.tensor([5, 6])
+        ])
+    ])
+])
+        
+expected_nt0 = torch.tensor([[[[[1, 2],
+                                [3, 4]]]],
+                             [[[[5, 6],
+                                [7, 8]]]]])
+
+expected_nt1 = nt.nested_tensor([
+    torch.tensor([[[[1, 2],
+                    [3, 4]]]]),
+    torch.tensor([[[[5, 6],
+                    [7, 8]]]]),
+])
+
+expected_nt2 = nt.nested_tensor([
+    nt.nested_tensor([
+        torch.tensor([[[1, 2],
+                       [3, 4]]]),
+    ]),
+    nt.nested_tensor([
+        torch.tensor([[[5, 6],
+                      [7, 8]]]),
+    ]),
+])
 
 class TestTensorMask(TestCase):
     def test_gen_nested_tensor(self):
-        nt = utils.gen_nested_tensor(seed=1, nested_dim=1, tensor_dim=1, size_low=2, size_high=2)
-        self.assertTrue(NT.is_nested_tensor(nt))
-        self.assertEqual(nt.nested_dim(), 1)
-        self.assertEqual(nt.size(), (2, 2))
-        self.assertEqual(nt[0].dim(), 1)
-        self.assertEqual(nt[0].size(), torch.Size([2]))
+        nt1 = utils.gen_nested_tensor(seed=1, nested_dim=1, tensor_dim=1, size_low=2, size_high=2)
+        self.assertTrue(nt.is_nested_tensor(nt1))
+        self.assertEqual(nt1.nested_dim(), 1)
+        self.assertEqual(nt1.size(), (2, 2))
+        self.assertEqual(nt1[0].dim(), 1)
+        self.assertEqual(nt1[0].size(), torch.Size([2]))
 
-        nt = utils.gen_nested_tensor(seed=1, nested_dim=2, tensor_dim=1, size_low=2, size_high=2)
-        self.assertTrue(NT.is_nested_tensor(nt))
-        self.assertEqual(nt.nested_dim(), 2)
-        self.assertEqual(nt.size(), (2, 2, 2))
-        self.assertEqual(nt[0].dim(), 2)
-        self.assertEqual(nt[0].size(), (2, 2))
-        self.assertEqual(nt[0][0].size(), torch.Size([2]))
+        nt1 = utils.gen_nested_tensor(seed=1, nested_dim=2, tensor_dim=1, size_low=2, size_high=2)
+        self.assertTrue(nt.is_nested_tensor(nt1))
+        self.assertEqual(nt1.nested_dim(), 2)
+        self.assertEqual(nt1.size(), (2, 2, 2))
+        self.assertEqual(nt1[0].dim(), 2)
+        self.assertEqual(nt1.nested_size(), nt.NestedSize([[[2],[2]], [[2],[2]]]))
 
-        nt = utils.gen_nested_tensor(seed=1, nested_dim=2, tensor_dim=2, size_low=2, size_high=2)
-        self.assertTrue(NT.is_nested_tensor(nt))
-        self.assertEqual(nt.nested_dim(), 2)
-        self.assertEqual(nt.size(), (2, 2, 2, 2))
-        self.assertEqual(nt[0].dim(), 3)
-        self.assertEqual(nt[0].size(), (2, 2, 2))
-        self.assertEqual(nt[0][0].size(), torch.Size([2, 2]))
-        self.assertEqual(nt[0][0][0].size(), torch.Size([2]))
+        nt1 = utils.gen_nested_tensor(seed=1, nested_dim=2, tensor_dim=2, size_low=2, size_high=2)
+        self.assertTrue(nt.is_nested_tensor(nt1))
+        self.assertEqual(nt1.nested_dim(), 2)
+        self.assertEqual(nt1.size(), (2, 2, 2, 2))
+        self.assertEqual(nt1[0].dim(), 3)
+        self.assertEqual(nt1[0].size(), (2, 2, 2))
+        self.assertEqual(nt1[0][0].size(), torch.Size([2, 2]))
+        self.assertEqual(nt1[0][0][0].size(), torch.Size([2]))
+        self.assertEqual(nt1.nested_size(), nt.NestedSize([[[2, 2],[2, 2]], [[2, 2],[2, 2]]]))
 
-        nt = utils.gen_nested_tensor(seed=1, nested_dim=2, tensor_dim=2, size_low=10, size_high=10)
-        self.assertTrue(NT.is_nested_tensor(nt))
-        self.assertEqual(nt.nested_dim(), 2)
-        self.assertEqual(nt.size(), (10, 10, 10, 10))
-        self.assertEqual(nt[0].dim(), 3)
-        self.assertEqual(nt[0].size(), (10, 10, 10))
-        self.assertEqual(nt[0][0].size(), torch.Size([10, 10]))
-        self.assertEqual(nt[0][0][0].size(), torch.Size([10]))
-
-    def test_to_tensor_mask(self):
-        nt = utils.gen_nested_tensor(1, 1, 1, size_low=2, size_high=2)
-        tensor, mask = nt.to_tensor_mask()
+    #
+    # Group of tests to test to_tensor_mask() 
+    # 
+    def test_to_tensor_mask_nt_dim_2(self):
+        nt1 = nt.nested_tensor([
+            torch.tensor([1, 2]),
+            torch.tensor([3, 4])
+        ])
+        tensor, mask = nt1.to_tensor_mask()
         self.assertEqual(mask, torch.tensor(True))
         self.assertEqual(mask.size(), torch.Size([]))
         self.assertEqual(mask.dim(), 0)
         self.assertEqual(tensor.size(), torch.Size([2, 2]))
         self.assertEqual(tensor.dim(), 2)
-        self.assertEqual(tensor.dim(), nt.dim())
+        self.assertEqual(tensor.dim(), nt1.dim())
 
-        nt = NT.nested_tensor([
-            NT.nested_tensor([
-                NT.nested_tensor([
-                    torch.tensor([1, 2])
-                ]),
-            ]),
-            NT.nested_tensor([
-                NT.nested_tensor([
-                    torch.tensor([3, 4]),
-                    torch.tensor([5, 6])
-                ])
-            ])
-        ])
-        
+    def test_to_tensor_mask_nt_dim_4(self):
         # mask_dim = None
-        tensor, mask = nt.to_tensor_mask()
+        tensor, mask = original_nt2.to_tensor_mask()
         self.assertEqual(mask, torch.tensor([[[ True, False]],
                                              [[ True, True]]]))
         self.assertEqual(mask.size(), torch.Size([2, 1, 2]))
         self.assertEqual(mask.dim(), 3)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 4)
-        self.assertEqual(tensor.dim(), nt.dim())
+        self.assertEqual(tensor.dim(), original_nt2.dim())
 
         # mask_dim = 0
-        tensor, mask = nt.to_tensor_mask(mask_dim=0)
+        tensor, mask = original_nt2.to_tensor_mask(mask_dim=0)
         self.assertEqual(mask, torch.tensor([[[ True, False]],
                                              [[ True, True]]]))
         self.assertEqual(mask.size(), torch.Size([2, 1, 2]))
         self.assertEqual(mask.dim(), 3)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 4)
-        self.assertEqual(tensor.dim(), nt.dim())
+        self.assertEqual(tensor.dim(), original_nt2.dim())
 
         # mask_dim = 1
-        tensor, mask = nt.to_tensor_mask(mask_dim=1)
+        tensor, mask = original_nt2.to_tensor_mask(mask_dim=1)
         self.assertEqual(mask, torch.tensor([[[ True, False]],
                                              [[ True, True]]]))
         self.assertEqual(mask.size(), torch.Size([2, 1, 2]))
@@ -99,27 +137,27 @@ class TestTensorMask(TestCase):
         self.assertEqual(tensor.dim(), 4)
 
         # mask_dim = 2
-        tensor, mask = nt.to_tensor_mask(mask_dim=2)
+        tensor, mask = original_nt2.to_tensor_mask(mask_dim=2)
         self.assertEqual(mask, torch.tensor([[[ True, False]],
                                              [[ True,  True]]]))
         self.assertEqual(mask.size(), torch.Size([2, 1, 2]))
         self.assertEqual(mask.dim(), 3)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 4)
-        self.assertEqual(tensor.dim(), nt.dim())
+        self.assertEqual(tensor.dim(), original_nt2.dim())
 
         # mask_dim = 3
-        tensor, mask = nt.to_tensor_mask(mask_dim=3)
+        tensor, mask = original_nt2.to_tensor_mask(mask_dim=3)
         self.assertEqual(mask, torch.tensor([[[ True, False]],
                                              [[ True, True]]]))
         self.assertEqual(mask.size(), torch.Size([2, 1, 2]))
         self.assertEqual(mask.dim(), 3)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 4)
-        self.assertEqual(tensor.dim(), nt.dim())
+        self.assertEqual(tensor.dim(), original_nt2.dim())
 
         # mask_dim = 4
-        tensor, mask = nt.to_tensor_mask(mask_dim=4)
+        tensor, mask = original_nt2.to_tensor_mask(mask_dim=4)
         self.assertEqual(mask, torch.tensor([[[[ True, True],
                                                [False, False]]],
                                              [[[ True, True],
@@ -128,184 +166,125 @@ class TestTensorMask(TestCase):
         self.assertEqual(mask.dim(), 4)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 4)
-        self.assertEqual(tensor.dim(), nt.dim())
+        self.assertEqual(tensor.dim(), original_nt2.dim())
 
-        nt = NT.nested_tensor([
-            NT.nested_tensor([
-                NT.nested_tensor([
-                    torch.tensor([[1, 2], 
-                                  [3, 4]])
-                ]),
-            ]),
-            NT.nested_tensor([
-                NT.nested_tensor([
-                    torch.tensor([[5, 6],
-                                  [7, 8]])
-                ]),
-            ])
-        ])
-
+    def test_to_tensor_mask_nt_dim_5(self):
         # mask_dim = None
-        tensor, mask = nt.to_tensor_mask()
+        tensor, mask = original_nt.to_tensor_mask()
         self.assertEqual(mask, torch.tensor(True))
         self.assertEqual(mask.size(), torch.Size([]))
         self.assertEqual(mask.dim(), 0)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 5)
-        self.assertEqual(tensor.dim(), nt.dim())
+        self.assertEqual(tensor.dim(), original_nt.dim())
 
         # mask_dim = 0
-        tensor, mask = nt.to_tensor_mask(mask_dim=0)
+        tensor, mask = original_nt.to_tensor_mask(mask_dim=0)
         self.assertEqual(mask, torch.tensor(True))
         self.assertEqual(mask.size(), torch.Size([]))
         self.assertEqual(mask.dim(), 0)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 5)
-        self.assertEqual(tensor.dim(), nt.dim())
+        self.assertEqual(tensor.dim(), original_nt.dim())
 
         # mask_dim = 1
-        tensor, mask = nt.to_tensor_mask(mask_dim=1)
+        tensor, mask = original_nt.to_tensor_mask(mask_dim=1)
         self.assertEqual(mask, torch.tensor([True, True]))
         self.assertEqual(mask.size(), torch.Size([2]))
         self.assertEqual(mask.dim(), 1)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 5)
-        self.assertEqual(tensor.dim(), nt.dim())
+        self.assertEqual(tensor.dim(), original_nt.dim())
 
         # mask_dim = 2
-        tensor, mask = nt.to_tensor_mask(mask_dim=2)
+        tensor, mask = original_nt.to_tensor_mask(mask_dim=2)
         self.assertEqual(mask, torch.tensor([[True], [True]]))
         self.assertEqual(mask.size(), torch.Size([2, 1]))
         self.assertEqual(mask.dim(), 2)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 5)
-        self.assertEqual(tensor.dim(), nt.dim())
+        self.assertEqual(tensor.dim(), original_nt.dim())
 
         # mask_dim = 3
-        tensor, mask = nt.to_tensor_mask(mask_dim=3)
+        tensor, mask = original_nt.to_tensor_mask(mask_dim=3)
         self.assertEqual(mask, torch.tensor([[[True]], [[True]]]))
         self.assertEqual(mask.size(), torch.Size([2, 1, 1]))
         self.assertEqual(mask.dim(), 3)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 5)
-        self.assertEqual(tensor.dim(), nt.dim())
+        self.assertEqual(tensor.dim(), original_nt.dim())
 
         # mask_dim = 4
-        tensor, mask = nt.to_tensor_mask(mask_dim=4)
+        tensor, mask = original_nt.to_tensor_mask(mask_dim=4)
         self.assertEqual(mask, torch.tensor([[[[True, True]]], [[[True, True]]]]))
         self.assertEqual(mask.size(), torch.Size([2, 1, 1, 2]))
         self.assertEqual(mask.dim(), 4)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 5)
-        self.assertEqual(tensor.dim(), nt.dim())
+        self.assertEqual(tensor.dim(), original_nt.dim())
 
-    def test_nested_tensor_from_tensor_mask(self):
-        original_nt = NT.nested_tensor([
-            NT.nested_tensor([
-                NT.nested_tensor([
-                    torch.tensor([[1, 2], 
-                                  [3, 4]])
-                ]),
-            ]),
-            NT.nested_tensor([
-                NT.nested_tensor([
-                    torch.tensor([[5, 6],
-                                  [7, 8]])
-                ]),
-            ])
-        ])
-
-        expected_nt0 = torch.tensor([[[[[1, 2],
-                                        [3, 4]]]],
-                                     [[[[5, 6],
-                                        [7, 8]]]]])
-
-        expected_nt1 = NT.nested_tensor([
-            torch.tensor([[[[1, 2],
-                            [3, 4]]]]),
-            torch.tensor([[[[5, 6],
-                            [7, 8]]]]),
-        ])
-
-        expected_nt2 = NT.nested_tensor([
-            NT.nested_tensor([
-                torch.tensor([[[1, 2],
-                               [3, 4]]]),
-            ]),
-            NT.nested_tensor([
-                torch.tensor([[[5, 6],
-                              [7, 8]]]),
-            ]),
-        ])
-
-        #
-        # mask_dim = None
-        #
+    #
+    # Group of tests to test nested_tensor_from_tensor_mask() 
+    #
+    def test_nested_tensor_from_tensor_mask_dim_none(self):
         tensor, mask = original_nt.to_tensor_mask()
         self.assertRaisesRegex(RuntimeError, 
                                "Mask has to have dimention > 0", 
-                               lambda: NT.nested_tensor_from_tensor_mask(tensor, mask))
+                               lambda: nt.nested_tensor_from_tensor_mask(tensor, mask))
 
-        #
-        # mask_dim = 1
-        #
+    def test_nested_tensor_from_tensor_mask_dim_1(self):
         tensor, mask = original_nt.to_tensor_mask(mask_dim = 1)
 
-        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask)
+        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask)
         self.assertEqual(expected_nt0, res_nt)
 
-        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=0)
+        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=0)
         self.assertEqual(expected_nt0, res_nt)
 
-        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=1)
+        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=1)
         self.assertEqual(expected_nt1, res_nt)
 
-        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
+        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
         self.assertEqual(expected_nt1, res_nt)
 
-        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=3)
+        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=3)
         self.assertEqual(expected_nt1, res_nt)
 
-        #
-        # mask_dim = 2
-        #
+    def test_nested_tensor_from_tensor_mask_dim_2(self):
         tensor, mask = original_nt.to_tensor_mask(mask_dim=2)
 
-        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask)
+        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask)
         self.assertEqual(expected_nt0, res_nt)
 
-        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=0)
+        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=0)
         self.assertEqual(expected_nt0, res_nt)
 
-        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=1)
+        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=1)
         self.assertEqual(expected_nt1, res_nt)
 
-        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
+        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
         self.assertEqual(expected_nt2, res_nt)
 
-        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=3)
+        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=3)
         self.assertEqual(expected_nt2, res_nt)
 
-        # 
-        # mask_dim = 3
-        #
+    def test_nested_tensor_from_tensor_mask_dim_3(self):
         tensor, mask = original_nt.to_tensor_mask(mask_dim=3)
 
-        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask)
+        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask)
         self.assertEqual(expected_nt0, res_nt)
         
-        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=0)
+        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=0)
         self.assertEqual(expected_nt0, res_nt)
 
-        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=1)
+        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=1)
         self.assertEqual(expected_nt1, res_nt)
 
-        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
+        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
         self.assertEqual(expected_nt2, res_nt)
 
-        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=3)
+        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=3)
         self.assertEqual(original_nt, res_nt)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_nested_tensor_masking.py
+++ b/test/test_nested_tensor_masking.py
@@ -10,67 +10,13 @@ import random
 import utils
 from utils import nested_size_to_list
 
-#
-# Test data
-#
-original_nt = nt.nested_tensor([
-    nt.nested_tensor([
-        nt.nested_tensor([
-            torch.tensor([[1, 2], 
-                           [3, 4]])
-        ]),
-     ]),
-    nt.nested_tensor([
-        nt.nested_tensor([
-            torch.tensor([[5, 6],
-                          [7, 8]])
-        ]),
-    ])
-])
-
-original_nt2 = nt.nested_tensor([
-    nt.nested_tensor([
-        nt.nested_tensor([
-            torch.tensor([1, 2])
-        ]),
-    ]),
-    nt.nested_tensor([
-        nt.nested_tensor([
-            torch.tensor([3, 4]),
-            torch.tensor([5, 6])
-        ])
-    ])
-])
-        
-expected_nt0 = torch.tensor([[[[[1, 2],
-                                [3, 4]]]],
-                             [[[[5, 6],
-                                [7, 8]]]]])
-
-expected_nt1 = nt.nested_tensor([
-    torch.tensor([[[[1, 2],
-                    [3, 4]]]]),
-    torch.tensor([[[[5, 6],
-                    [7, 8]]]]),
-])
-
-expected_nt2 = nt.nested_tensor([
-    nt.nested_tensor([
-        torch.tensor([[[1, 2],
-                       [3, 4]]]),
-    ]),
-    nt.nested_tensor([
-        torch.tensor([[[5, 6],
-                       [7, 8]]]),
-    ]),
-])
-
 class TestTensorMask(TestCase):
     def test_gen_nested_tensor(self):
         nt1 = utils.gen_nested_tensor(seed=1, nested_dim=1, tensor_dim=1, size_low=2, size_high=2)
         self.assertTrue(nt.is_nested_tensor(nt1))
         self.assertEqual(nt1.nested_dim(), 1)
         self.assertEqual(nt1.size(), (2, 2))
+        self.assertEqual(nested_size_to_list(nt1.nested_size()), [[2],[2]])
         self.assertEqual(nt1[0].dim(), 1)
         self.assertEqual(nt1[0].size(), torch.Size([2]))
 
@@ -79,7 +25,7 @@ class TestTensorMask(TestCase):
         self.assertEqual(nt1.nested_dim(), 2)
         self.assertEqual(nt1.size(), (2, 2, 2))
         self.assertEqual(nt1[0].dim(), 2)
-        self.assertEqual(nt1.nested_size(), nested_size_to_list([[[2],[2]], [[2],[2]]]))
+        self.assertEqual(nested_size_to_list(nt1.nested_size()), [[[2],[2]], [[2],[2]]])
 
         nt1 = utils.gen_nested_tensor(seed=1, nested_dim=2, tensor_dim=2, size_low=2, size_high=2)
         self.assertTrue(nt.is_nested_tensor(nt1))
@@ -89,7 +35,7 @@ class TestTensorMask(TestCase):
         self.assertEqual(nt1[0].size(), (2, 2, 2))
         self.assertEqual(nt1[0][0].size(), torch.Size([2, 2]))
         self.assertEqual(nt1[0][0][0].size(), torch.Size([2]))
-        self.assertEqual(nt1.nested_size(), nested_size_to_list([[[2, 2],[2, 2]], [[2, 2],[2, 2]]]))
+        self.assertEqual(nested_size_to_list(nt1.nested_size()), [[[2, 2],[2, 2]], [[2, 2],[2, 2]]])
 
     #
     # Group of tests to test to_tensor_mask() 
@@ -107,6 +53,20 @@ class TestTensorMask(TestCase):
         self.assertEqual(res_tensor, exp_tensor)
 
     def test_to_tensor_mask_nt_dim_4(self):
+        original_nt2 = nt.nested_tensor([
+            nt.nested_tensor([
+                nt.nested_tensor([
+                    torch.tensor([1, 2])
+                ]),
+            ]),
+            nt.nested_tensor([
+                nt.nested_tensor([
+                    torch.tensor([3, 4]),
+                    torch.tensor([5, 6])
+                ])
+            ])
+        ])
+
         # mask_dim = None
         res_tensor, res_mask = original_nt2.to_tensor_mask()
         exp_mask = torch.tensor([[[ True, False]],
@@ -147,6 +107,21 @@ class TestTensorMask(TestCase):
         self.assertEqual(res_tensor, exp_tensor)
 
     def test_to_tensor_mask_nt_dim_5(self):
+        original_nt = nt.nested_tensor([
+            nt.nested_tensor([
+                nt.nested_tensor([
+                    torch.tensor([[1, 2], 
+                                [3, 4]])
+                ]),
+            ]),
+            nt.nested_tensor([
+                nt.nested_tensor([
+                    torch.tensor([[5, 6],
+                                [7, 8]])
+                ]),
+            ])
+        ])
+
         # mask_dim = None
         res_tensor, res_mask = original_nt.to_tensor_mask()
         exp_tensor = torch.tensor([[[[[1, 2], [3, 4]]]],
@@ -196,12 +171,54 @@ class TestTensorMask(TestCase):
     # Group of tests to test nested_tensor_from_tensor_mask() 
     #
     def test_nested_tensor_from_tensor_mask_dim_none(self):
+        original_nt = nt.nested_tensor([
+            nt.nested_tensor([
+                nt.nested_tensor([
+                    torch.tensor([[1, 2], 
+                                [3, 4]])
+                ]),
+            ]),
+            nt.nested_tensor([
+                nt.nested_tensor([
+                    torch.tensor([[5, 6],
+                                [7, 8]])
+                ]),
+            ])
+        ])
+
         tensor, mask = original_nt.to_tensor_mask()
         self.assertRaisesRegex(RuntimeError, 
                                "Mask has to have dimention > 0", 
                                lambda: nt.nested_tensor_from_tensor_mask(tensor, mask))
 
     def test_nested_tensor_from_tensor_mask_dim_1(self):
+        original_nt = nt.nested_tensor([
+            nt.nested_tensor([
+                nt.nested_tensor([
+                    torch.tensor([[1, 2], 
+                                [3, 4]])
+                ]),
+            ]),
+            nt.nested_tensor([
+                nt.nested_tensor([
+                    torch.tensor([[5, 6],
+                                [7, 8]])
+                ]),
+            ])
+        ])
+
+        expected_nt0 = torch.tensor([[[[[1, 2],
+                                        [3, 4]]]],
+                                     [[[[5, 6],
+                                        [7, 8]]]]])
+
+        expected_nt1 = nt.nested_tensor([
+            torch.tensor([[[[1, 2],
+                            [3, 4]]]]),
+            torch.tensor([[[[5, 6],
+                            [7, 8]]]]),
+        ])
+
         tensor, mask = original_nt.to_tensor_mask(mask_dim = 1)
 
         res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask)
@@ -220,6 +237,44 @@ class TestTensorMask(TestCase):
         self.assertEqual(expected_nt1, res_nt)
 
     def test_nested_tensor_from_tensor_mask_dim_2(self):
+        original_nt = nt.nested_tensor([
+            nt.nested_tensor([
+                nt.nested_tensor([
+                    torch.tensor([[1, 2], 
+                                [3, 4]])
+                ]),
+            ]),
+            nt.nested_tensor([
+                nt.nested_tensor([
+                    torch.tensor([[5, 6],
+                                [7, 8]])
+                ]),
+            ])
+        ])
+
+        expected_nt0 = torch.tensor([[[[[1, 2],
+                                        [3, 4]]]],
+                                     [[[[5, 6],
+                                        [7, 8]]]]])
+
+        expected_nt1 = nt.nested_tensor([
+            torch.tensor([[[[1, 2],
+                            [3, 4]]]]),
+            torch.tensor([[[[5, 6],
+                            [7, 8]]]]),
+        ])
+
+        expected_nt2 = nt.nested_tensor([
+            nt.nested_tensor([
+                torch.tensor([[[1, 2],
+                               [3, 4]]]),
+            ]),
+            nt.nested_tensor([
+                torch.tensor([[[5, 6],
+                               [7, 8]]]),
+            ]),
+        ])
+
         tensor, mask = original_nt.to_tensor_mask(mask_dim=2)
 
         res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask)
@@ -238,6 +293,44 @@ class TestTensorMask(TestCase):
         self.assertEqual(expected_nt2, res_nt)
 
     def test_nested_tensor_from_tensor_mask_dim_3(self):
+        original_nt = nt.nested_tensor([
+            nt.nested_tensor([
+                nt.nested_tensor([
+                    torch.tensor([[1, 2], 
+                                [3, 4]])
+                ]),
+            ]),
+            nt.nested_tensor([
+                nt.nested_tensor([
+                    torch.tensor([[5, 6],
+                                [7, 8]])
+                ]),
+            ])
+        ])
+        
+        expected_nt0 = torch.tensor([[[[[1, 2],
+                                        [3, 4]]]],
+                                     [[[[5, 6],
+                                        [7, 8]]]]])
+
+        expected_nt1 = nt.nested_tensor([
+            torch.tensor([[[[1, 2],
+                            [3, 4]]]]),
+            torch.tensor([[[[5, 6],
+                            [7, 8]]]]),
+        ])
+
+        expected_nt2 = nt.nested_tensor([
+            nt.nested_tensor([
+                torch.tensor([[[1, 2],
+                               [3, 4]]]),
+            ]),
+            nt.nested_tensor([
+                torch.tensor([[[5, 6],
+                               [7, 8]]]),
+            ]),
+        ])
+
         tensor, mask = original_nt.to_tensor_mask(mask_dim=3)
 
         res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask)

--- a/test/test_nested_tensor_masking.py
+++ b/test/test_nested_tensor_masking.py
@@ -230,11 +230,9 @@ class TestTensorMask(TestCase):
         res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=1)
         self.assertEqual(expected_nt1, res_nt)
 
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
-        self.assertEqual(expected_nt1, res_nt)
-
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=3)
-        self.assertEqual(expected_nt1, res_nt)
+        # nested_dim is bigger than masks dimension 
+        self.assertRaises(ValueError, lambda: nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2))
+        self.assertRaises(ValueError, lambda: nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=3))
 
     def test_nested_tensor_from_tensor_mask_dim_2(self):
         original_nt = nt.nested_tensor([
@@ -289,8 +287,8 @@ class TestTensorMask(TestCase):
         res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
         self.assertEqual(expected_nt2, res_nt)
 
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=3)
-        self.assertEqual(expected_nt2, res_nt)
+        # nested_dim is bigger than masks dimension 
+        self.assertRaises(ValueError, lambda: nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=3))
 
     def test_nested_tensor_from_tensor_mask_dim_3(self):
         original_nt = nt.nested_tensor([

--- a/test/test_nested_tensor_masking.py
+++ b/test/test_nested_tensor_masking.py
@@ -8,6 +8,7 @@ import unittest
 from utils import TestCase
 import random
 import utils
+from utils import nested_size_to_list
 
 #
 # Test data
@@ -60,7 +61,7 @@ expected_nt2 = nt.nested_tensor([
     ]),
     nt.nested_tensor([
         torch.tensor([[[5, 6],
-                      [7, 8]]]),
+                       [7, 8]]]),
     ]),
 ])
 
@@ -78,7 +79,7 @@ class TestTensorMask(TestCase):
         self.assertEqual(nt1.nested_dim(), 2)
         self.assertEqual(nt1.size(), (2, 2, 2))
         self.assertEqual(nt1[0].dim(), 2)
-        self.assertEqual(nt1.nested_size(), nt.NestedSize([[[2],[2]], [[2],[2]]]))
+        self.assertEqual(nt1.nested_size(), nested_size_to_list([[[2],[2]], [[2],[2]]]))
 
         nt1 = utils.gen_nested_tensor(seed=1, nested_dim=2, tensor_dim=2, size_low=2, size_high=2)
         self.assertTrue(nt.is_nested_tensor(nt1))
@@ -88,7 +89,7 @@ class TestTensorMask(TestCase):
         self.assertEqual(nt1[0].size(), (2, 2, 2))
         self.assertEqual(nt1[0][0].size(), torch.Size([2, 2]))
         self.assertEqual(nt1[0][0][0].size(), torch.Size([2]))
-        self.assertEqual(nt1.nested_size(), nt.NestedSize([[[2, 2],[2, 2]], [[2, 2],[2, 2]]]))
+        self.assertEqual(nt1.nested_size(), nested_size_to_list([[[2, 2],[2, 2]], [[2, 2],[2, 2]]]))
 
     #
     # Group of tests to test to_tensor_mask() 
@@ -98,130 +99,98 @@ class TestTensorMask(TestCase):
             torch.tensor([1, 2]),
             torch.tensor([3, 4])
         ])
-        tensor, mask = nt1.to_tensor_mask()
-        self.assertEqual(mask, torch.tensor(True))
-        self.assertEqual(mask.size(), torch.Size([]))
-        self.assertEqual(mask.dim(), 0)
-        self.assertEqual(tensor.size(), torch.Size([2, 2]))
-        self.assertEqual(tensor.dim(), 2)
-        self.assertEqual(tensor.dim(), nt1.dim())
+        exp_tensor = torch.tensor([[1, 2], [3, 4]])
+        exp_mask = torch.tensor(True)
+
+        res_tensor, res_mask = nt1.to_tensor_mask()
+        self.assertEqual(res_mask, exp_mask)
+        self.assertEqual(res_tensor, exp_tensor)
 
     def test_to_tensor_mask_nt_dim_4(self):
         # mask_dim = None
-        tensor, mask = original_nt2.to_tensor_mask()
-        self.assertEqual(mask, torch.tensor([[[ True, False]],
-                                             [[ True, True]]]))
-        self.assertEqual(mask.size(), torch.Size([2, 1, 2]))
-        self.assertEqual(mask.dim(), 3)
-        self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
-        self.assertEqual(tensor.dim(), 4)
-        self.assertEqual(tensor.dim(), original_nt2.dim())
+        res_tensor, res_mask = original_nt2.to_tensor_mask()
+        exp_mask = torch.tensor([[[ True, False]],
+                                 [[ True, True]]])
+        exp_tensor = torch.tensor([[[[1, 2], [0, 0]]],
+                                   [[[3, 4], [5, 6]]]])
+
+        self.assertEqual(res_mask, exp_mask)
+        self.assertEqual(res_tensor, exp_tensor)
 
         # mask_dim = 0
-        tensor, mask = original_nt2.to_tensor_mask(mask_dim=0)
-        self.assertEqual(mask, torch.tensor([[[ True, False]],
-                                             [[ True, True]]]))
-        self.assertEqual(mask.size(), torch.Size([2, 1, 2]))
-        self.assertEqual(mask.dim(), 3)
-        self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
-        self.assertEqual(tensor.dim(), 4)
-        self.assertEqual(tensor.dim(), original_nt2.dim())
+        res_tensor, res_mask = original_nt2.to_tensor_mask(mask_dim=0)
+        self.assertEqual(res_mask, exp_mask)
+        self.assertEqual(res_tensor, exp_tensor)
 
         # mask_dim = 1
-        tensor, mask = original_nt2.to_tensor_mask(mask_dim=1)
-        self.assertEqual(mask, torch.tensor([[[ True, False]],
-                                             [[ True, True]]]))
-        self.assertEqual(mask.size(), torch.Size([2, 1, 2]))
-        self.assertEqual(mask.dim(), 3)
-        self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
-        self.assertEqual(tensor.dim(), 4)
+        res_tensor, res_mask = original_nt2.to_tensor_mask(mask_dim=1)
+        self.assertEqual(res_mask, exp_mask)
+        self.assertEqual(res_tensor, exp_tensor)
 
         # mask_dim = 2
-        tensor, mask = original_nt2.to_tensor_mask(mask_dim=2)
-        self.assertEqual(mask, torch.tensor([[[ True, False]],
-                                             [[ True,  True]]]))
-        self.assertEqual(mask.size(), torch.Size([2, 1, 2]))
-        self.assertEqual(mask.dim(), 3)
-        self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
-        self.assertEqual(tensor.dim(), 4)
-        self.assertEqual(tensor.dim(), original_nt2.dim())
+        res_tensor, res_mask = original_nt2.to_tensor_mask(mask_dim=2)
+        self.assertEqual(res_mask, exp_mask)
+        self.assertEqual(res_tensor, exp_tensor)
 
         # mask_dim = 3
-        tensor, mask = original_nt2.to_tensor_mask(mask_dim=3)
-        self.assertEqual(mask, torch.tensor([[[ True, False]],
-                                             [[ True, True]]]))
-        self.assertEqual(mask.size(), torch.Size([2, 1, 2]))
-        self.assertEqual(mask.dim(), 3)
-        self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
-        self.assertEqual(tensor.dim(), 4)
-        self.assertEqual(tensor.dim(), original_nt2.dim())
+        res_tensor, res_mask = original_nt2.to_tensor_mask(mask_dim=3)
+        self.assertEqual(res_mask, exp_mask)
+        self.assertEqual(res_tensor, exp_tensor)
 
         # mask_dim = 4
-        tensor, mask = original_nt2.to_tensor_mask(mask_dim=4)
-        self.assertEqual(mask, torch.tensor([[[[ True, True],
-                                               [False, False]]],
-                                             [[[ True, True],
-                                               [ True, True]]]]))
-        self.assertEqual(mask.size(), torch.Size([2, 1, 2, 2]))
-        self.assertEqual(mask.dim(), 4)
-        self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
-        self.assertEqual(tensor.dim(), 4)
-        self.assertEqual(tensor.dim(), original_nt2.dim())
+        res_tensor, res_mask = original_nt2.to_tensor_mask(mask_dim=4)
+        exp_tensor = torch.tensor([[[[1, 2], [0, 0]]],
+                                    [[[3, 4], [5, 6]]]])
+        exp_mask = torch.tensor([[[[ True,  True], [False, False]]],
+                                 [[[ True,  True], [ True,  True]]]])
+        self.assertEqual(res_mask, exp_mask)
+        self.assertEqual(res_tensor, exp_tensor)
 
     def test_to_tensor_mask_nt_dim_5(self):
         # mask_dim = None
-        tensor, mask = original_nt.to_tensor_mask()
-        self.assertEqual(mask, torch.tensor(True))
-        self.assertEqual(mask.size(), torch.Size([]))
-        self.assertEqual(mask.dim(), 0)
-        self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
-        self.assertEqual(tensor.dim(), 5)
-        self.assertEqual(tensor.dim(), original_nt.dim())
+        res_tensor, res_mask = original_nt.to_tensor_mask()
+        exp_tensor = torch.tensor([[[[[1, 2], [3, 4]]]],
+                                   [[[[5, 6], [7, 8]]]]])
+        exp_mask = torch.tensor(True)
+        self.assertEqual(res_mask, exp_mask)
+        self.assertEqual(res_tensor, exp_tensor)
 
         # mask_dim = 0
-        tensor, mask = original_nt.to_tensor_mask(mask_dim=0)
-        self.assertEqual(mask, torch.tensor(True))
-        self.assertEqual(mask.size(), torch.Size([]))
-        self.assertEqual(mask.dim(), 0)
-        self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
-        self.assertEqual(tensor.dim(), 5)
-        self.assertEqual(tensor.dim(), original_nt.dim())
+        res_tensor, res_mask = original_nt.to_tensor_mask(mask_dim=0)
+        self.assertEqual(res_mask, exp_mask)
+        self.assertEqual(res_tensor, exp_tensor)
 
         # mask_dim = 1
-        tensor, mask = original_nt.to_tensor_mask(mask_dim=1)
-        self.assertEqual(mask, torch.tensor([True, True]))
-        self.assertEqual(mask.size(), torch.Size([2]))
-        self.assertEqual(mask.dim(), 1)
-        self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
-        self.assertEqual(tensor.dim(), 5)
-        self.assertEqual(tensor.dim(), original_nt.dim())
+        res_tensor, res_mask = original_nt.to_tensor_mask(mask_dim=1)
+        exp_tensor = torch.tensor([[[[[1, 2], [3, 4]]]],
+                                   [[[[5, 6], [7, 8]]]]])
+        exp_mask = torch.tensor([True, True])
+        self.assertEqual(res_mask, exp_mask)
+        self.assertEqual(res_tensor, exp_tensor)
 
         # mask_dim = 2
-        tensor, mask = original_nt.to_tensor_mask(mask_dim=2)
-        self.assertEqual(mask, torch.tensor([[True], [True]]))
-        self.assertEqual(mask.size(), torch.Size([2, 1]))
-        self.assertEqual(mask.dim(), 2)
-        self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
-        self.assertEqual(tensor.dim(), 5)
-        self.assertEqual(tensor.dim(), original_nt.dim())
-
+        res_tensor, res_mask = original_nt.to_tensor_mask(mask_dim=2)
+        exp_mask = torch.tensor([[True], [True]])
+        exp_tensor = torch.tensor([[[[[1, 2], [3, 4]]]],
+                                   [[[[5, 6], [7, 8]]]]])
+        self.assertEqual(res_mask, exp_mask)
+        self.assertEqual(res_tensor, exp_tensor)
+        
         # mask_dim = 3
-        tensor, mask = original_nt.to_tensor_mask(mask_dim=3)
-        self.assertEqual(mask, torch.tensor([[[True]], [[True]]]))
-        self.assertEqual(mask.size(), torch.Size([2, 1, 1]))
-        self.assertEqual(mask.dim(), 3)
-        self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
-        self.assertEqual(tensor.dim(), 5)
-        self.assertEqual(tensor.dim(), original_nt.dim())
+        res_tensor, res_mask = original_nt.to_tensor_mask(mask_dim=3)
+        exp_mask = torch.tensor([[[True]], [[True]]])
+        exp_tensor = torch.tensor([[[[[1, 2], [3, 4]]]],
+                                   [[[[5, 6], [7, 8]]]]])
+        self.assertEqual(res_mask, exp_mask)
+        self.assertEqual(res_tensor, exp_tensor)    
 
         # mask_dim = 4
-        tensor, mask = original_nt.to_tensor_mask(mask_dim=4)
-        self.assertEqual(mask, torch.tensor([[[[True, True]]], [[[True, True]]]]))
-        self.assertEqual(mask.size(), torch.Size([2, 1, 1, 2]))
-        self.assertEqual(mask.dim(), 4)
-        self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
-        self.assertEqual(tensor.dim(), 5)
-        self.assertEqual(tensor.dim(), original_nt.dim())
+        res_tensor, res_mask = original_nt.to_tensor_mask(mask_dim=4)
+        exp_mask = torch.tensor([[[[True, True]]],[[[True, True]]]])
+        exp_tensor = torch.tensor([[[[[1, 2], [3, 4]]]],
+                                   [[[[5, 6], [7, 8]]]]])
+        self.assertEqual(res_mask, exp_mask)
+        self.assertEqual(res_tensor, exp_tensor) 
 
     #
     # Group of tests to test nested_tensor_from_tensor_mask() 

--- a/test/test_nested_tensor_masking.py
+++ b/test/test_nested_tensor_masking.py
@@ -3,7 +3,7 @@ import functools
 import pdb
 import sys
 import torch
-import nestedtensor
+import nestedtensor as NT
 import unittest
 from utils import TestCase
 import random
@@ -11,34 +11,271 @@ import random
 import utils
 
 class TestTensorMask(TestCase):
-    # TODO: test comparison operator fails if nested_size doesn't agree.
+    def test_gen_nested_tensor(self):
+        nt = utils.gen_nested_tensor(seed=1, nested_dim=1, tensor_dim=1, size_low=2, size_high=2)
+        self.assertTrue(NT.is_nested_tensor(nt))
+        self.assertEqual(nt.nested_dim(), 1)
+        self.assertEqual(nt.size(), (2, 2))
+        self.assertEqual(nt[0].dim(), 1)
+        self.assertEqual(nt[0].size(), torch.Size([2]))
 
-    def test_simple(self):
-        values = [torch.rand(i) for i in range(10)]
-        random.shuffle(values)
-        nt = nestedtensor.nested_tensor(values)
-        tensor, mask = nt.to_tensor_mask()
+        nt = utils.gen_nested_tensor(seed=1, nested_dim=2, tensor_dim=1, size_low=2, size_high=2)
+        self.assertTrue(NT.is_nested_tensor(nt))
+        self.assertEqual(nt.nested_dim(), 2)
+        self.assertEqual(nt.size(), (2, 2, 2))
+        self.assertEqual(nt[0].dim(), 1)
+        self.assertEqual(nt[0].size(), (2, 2))
+        self.assertEqual(nt[0][0].size(), torch.Size([2]))
 
-    def test_nested(self):
-        nt = utils.gen_nested_tensor(2, 2, 2)
-        tensor, mask = nt.to_tensor_mask()
+        nt = utils.gen_nested_tensor(seed=1, nested_dim=2, tensor_dim=2, size_low=2, size_high=2)
+        self.assertTrue(NT.is_nested_tensor(nt))
+        self.assertEqual(nt.nested_dim(), 2)
+        self.assertEqual(nt.size(), (2, 2, 2, 2))
+        self.assertEqual(nt[0].dim(), 1)
+        self.assertEqual(nt[0].size(), (2, 2, 2))
+        self.assertEqual(nt[0][0].size(), torch.Size([2, 2]))
+        self.assertEqual(nt[0][0][0].size(), torch.Size([2]))
 
-    def test_tensor_mask(self):
-        nt = utils.gen_nested_tensor(2, 2, 2, size_low=1, size_high=2)
-        tensor, mask = nt.to_tensor_mask()
-        nt1 = nestedtensor.nested_tensor_from_tensor_mask(
-            tensor, mask, nested_dim=nt.nested_dim())
-        self.assertEqual(nt, nt1)
-        nt2 = nestedtensor.nested_tensor_from_tensor_mask(
-            tensor, mask)
-        self.assertEqual(nt, nt2)
+        nt = utils.gen_nested_tensor(seed=1, nested_dim=2, tensor_dim=2, size_low=10, size_high=10)
+        self.assertTrue(NT.is_nested_tensor(nt))
+        self.assertEqual(nt.nested_dim(), 2)
+        self.assertEqual(nt.size(), (10, 10, 10, 10))
+        self.assertEqual(nt[0].dim(), 1)
+        self.assertEqual(nt[0].size(), (10, 10, 10))
+        self.assertEqual(nt[0][0].size(), torch.Size([10, 10]))
+        self.assertEqual(nt[0][0][0].size(), torch.Size([10]))
 
-    def test_tensor_mask_lowdim(self):
-        values = [torch.rand(1, 2) for i in range(10)]
-        values = [values[1:i] for i in range(2, 10)]
-        nt = nestedtensor.nested_tensor(values)
+    def test_to_tensor_mask(self):
+        nt = utils.gen_nested_tensor(1, 1, 1, size_low=2, size_high=2)
         tensor, mask = nt.to_tensor_mask()
-        self.assertTrue([len(value) for value in values] == list(mask.sum(-1)))
+        self.assertEqual(mask, torch.tensor(True))
+        self.assertEqual(mask.size(), torch.Size([]))
+        self.assertEqual(mask.dim(), 0)
+        self.assertEqual(tensor.size(), torch.Size([2, 2]))
+        self.assertEqual(tensor.dim(), 2)
+
+        nt = NT.nested_tensor([
+            NT.nested_tensor([
+                NT.nested_tensor([
+                    torch.tensor([1, 2])
+                ]),
+            ]),
+            NT.nested_tensor([
+                NT.nested_tensor([
+                    torch.tensor([3, 4]),
+                    torch.tensor([5, 6])
+                ])
+            ])
+        ])
+        
+        # mask_dim = None
+        tensor, mask = nt.to_tensor_mask()
+        self.assertEqual(mask, torch.tensor([[[ True, False]],
+                                             [[ True,  True]]]))
+        self.assertEqual(mask.size(), torch.Size([2, 1, 2]))
+        self.assertEqual(mask.dim(), 3)
+        self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
+        self.assertEqual(tensor.dim(), 4)
+
+        # mask_dim = 0
+        tensor, mask = nt.to_tensor_mask(mask_dim=0)
+        self.assertEqual(mask, torch.tensor([[[ True, False]],
+                                             [[ True,  True]]]))
+        self.assertEqual(mask.size(), torch.Size([2, 1, 2]))
+        self.assertEqual(mask.dim(), 3)
+        self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
+        self.assertEqual(tensor.dim(), 4)
+
+        # mask_dim = 1
+        tensor, mask = nt.to_tensor_mask(mask_dim=1)
+        self.assertEqual(mask, torch.tensor([[[ True, False]],
+                                             [[ True,  True]]]))
+        self.assertEqual(mask.size(), torch.Size([2, 1, 2]))
+        self.assertEqual(mask.dim(), 3)
+        self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
+        self.assertEqual(tensor.dim(), 4)
+
+        # mask_dim = 2
+        tensor, mask = nt.to_tensor_mask(mask_dim=2)
+        self.assertEqual(mask, torch.tensor([[[ True, False]],
+                                             [[ True,  True]]]))
+        self.assertEqual(mask.size(), torch.Size([2, 1, 2]))
+        self.assertEqual(mask.dim(), 3)
+        self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
+        self.assertEqual(tensor.dim(), 4)
+
+        # mask_dim = 3
+        tensor, mask = nt.to_tensor_mask(mask_dim=3)
+        self.assertEqual(mask, torch.tensor([[[ True, False]],
+                                             [[ True,  True]]]))
+        self.assertEqual(mask.size(), torch.Size([2, 1, 2]))
+        self.assertEqual(mask.dim(), 3)
+        self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
+        self.assertEqual(tensor.dim(), 4)
+
+        # mask_dim = 4
+        tensor, mask = nt.to_tensor_mask(mask_dim=4)
+        self.assertEqual(mask, torch.tensor([[[[ True,  True],
+                                               [False, False]]],
+                                             [[[ True,  True],
+                                               [ True,  True]]]]))
+        self.assertEqual(mask.size(), torch.Size([2, 1, 2, 2]))
+        self.assertEqual(mask.dim(), 4)
+        self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
+        self.assertEqual(tensor.dim(), 4)
+
+        nt = NT.nested_tensor([
+            NT.nested_tensor([
+                NT.nested_tensor([
+                    torch.tensor([[1, 2], 
+                                  [3, 4]])
+                ]),
+            ]),
+            NT.nested_tensor([
+                NT.nested_tensor([
+                    torch.tensor([[5, 6],
+                                  [7, 8]])
+                ]),
+            ])
+        ])
+
+        # mask_dim = None
+        tensor, mask = nt.to_tensor_mask()
+        self.assertEqual(mask, torch.tensor(True))
+        self.assertEqual(mask.size(), torch.Size([]))
+        self.assertEqual(mask.dim(), 0)
+        self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
+        self.assertEqual(tensor.dim(), 5)
+
+        # mask_dim = 0
+        tensor, mask = nt.to_tensor_mask(mask_dim=0)
+        self.assertEqual(mask, torch.tensor(True))
+        self.assertEqual(mask.size(), torch.Size([]))
+        self.assertEqual(mask.dim(), 0)
+        self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
+        self.assertEqual(tensor.dim(), 5)
+
+        # mask_dim = 1
+        tensor, mask = nt.to_tensor_mask(mask_dim=1)
+        self.assertEqual(mask, torch.tensor([True, True]))
+        self.assertEqual(mask.size(), torch.Size([2]))
+        self.assertEqual(mask.dim(), 1)
+        self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
+        self.assertEqual(tensor.dim(), 5)
+
+        # mask_dim = 2
+        tensor, mask = nt.to_tensor_mask(mask_dim=2)
+        self.assertEqual(mask, torch.tensor([[True], [True]]))
+        self.assertEqual(mask.size(), torch.Size([2, 1]))
+        self.assertEqual(mask.dim(), 2)
+        self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
+        self.assertEqual(tensor.dim(), 5)
+
+        # mask_dim = 3
+        tensor, mask = nt.to_tensor_mask(mask_dim=3)
+        self.assertEqual(mask, torch.tensor([[[True]], [[True]]]))
+        self.assertEqual(mask.size(), torch.Size([2, 1, 1]))
+        self.assertEqual(mask.dim(), 3)
+        self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
+        self.assertEqual(tensor.dim(), 5)
+
+        # mask_dim = 4
+        tensor, mask = nt.to_tensor_mask(mask_dim=4)
+        self.assertEqual(mask, torch.tensor([[[[True, True]]], [[[True, True]]]]))
+        self.assertEqual(mask.size(), torch.Size([2, 1, 1, 2]))
+        self.assertEqual(mask.dim(), 4)
+        self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
+        self.assertEqual(tensor.dim(), 5)
+
+    def test_nested_tensor_from_tensor_mask(self):
+        original_nt = NT.nested_tensor([
+            NT.nested_tensor([
+                NT.nested_tensor([
+                    torch.tensor([[1, 2], 
+                                  [3, 4]])
+                ]),
+            ]),
+            NT.nested_tensor([
+                NT.nested_tensor([
+                    torch.tensor([[5, 6],
+                                  [7, 8]])
+                ]),
+            ])
+        ])
+
+        # 
+        # mask_dim = 4
+        #
+
+        # nested_dim = 4
+        tensor, mask = original_nt.to_tensor_mask(mask_dim=4)
+        nt4 = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=4)
+        self.assertEqual(original_nt, nt4)
+
+        # nested_dim = 3
+        nt3 = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=3)
+        expected_nt3 = NT.nested_tensor([
+            NT.nested_tensor([
+                NT.nested_tensor([
+                    torch.tensor([[1, 2],
+                                  [3, 4]]),
+                ]),
+            ]),
+            NT.nested_tensor([
+                NT.nested_tensor([
+                    torch.tensor([[5, 6],
+                                 [7, 8]]),
+                ]),
+            ]),
+        ])
+        self.assertEqual(expected_nt3, nt3)
+
+        # nested_dim = 2
+        nt2 = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
+        expected_nt2 = NT.nested_tensor([
+            NT.nested_tensor([
+                torch.tensor([[[1, 2],
+                               [3, 4]]]),
+            ]),
+            NT.nested_tensor([
+                torch.tensor([[[5, 6],
+                              [7, 8]]]),
+            ]),
+        ])
+        self.assertEqual(expected_nt2, nt2)
+
+        # nested_dim = 1
+        nt1 = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=1)
+        expected_nt1 = NT.nested_tensor([
+            torch.tensor([[[[1, 2],
+                            [3, 4]]]]),
+            torch.tensor([[[[5, 6],
+                            [7, 8]]]]),
+        ])
+        self.assertEqual(expected_nt1, nt1)
+
+        # nested_dim = 0
+        nt0 = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=0)
+        expected_nt0 = torch.tensor([
+                                        [[[[1, 2],
+                                        [3, 4]]]],
+                                        [[[[5, 6],
+                                        [7, 8]]]]
+                                    ])
+        self.assertEqual(expected_nt0, nt0)
+
+        # nested_dim = None
+        nt = NT.nested_tensor_from_tensor_mask(tensor, mask)
+        self.assertEqual(expected_nt0, nt)
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# TODO: 
+# 1. test cases for all asserts
+# 2. test cases for all errors 
+# 3. test cases for NT from tensor+mask
+# 4. ask if tensor(True) mask + tensor -> NT? its an error now.
+#
+#

--- a/test/test_nested_tensor_masking.py
+++ b/test/test_nested_tensor_masking.py
@@ -23,7 +23,7 @@ class TestTensorMask(TestCase):
         self.assertTrue(NT.is_nested_tensor(nt))
         self.assertEqual(nt.nested_dim(), 2)
         self.assertEqual(nt.size(), (2, 2, 2))
-        self.assertEqual(nt[0].dim(), 1)
+        self.assertEqual(nt[0].dim(), 2)
         self.assertEqual(nt[0].size(), (2, 2))
         self.assertEqual(nt[0][0].size(), torch.Size([2]))
 
@@ -31,7 +31,7 @@ class TestTensorMask(TestCase):
         self.assertTrue(NT.is_nested_tensor(nt))
         self.assertEqual(nt.nested_dim(), 2)
         self.assertEqual(nt.size(), (2, 2, 2, 2))
-        self.assertEqual(nt[0].dim(), 1)
+        self.assertEqual(nt[0].dim(), 3)
         self.assertEqual(nt[0].size(), (2, 2, 2))
         self.assertEqual(nt[0][0].size(), torch.Size([2, 2]))
         self.assertEqual(nt[0][0][0].size(), torch.Size([2]))
@@ -40,7 +40,7 @@ class TestTensorMask(TestCase):
         self.assertTrue(NT.is_nested_tensor(nt))
         self.assertEqual(nt.nested_dim(), 2)
         self.assertEqual(nt.size(), (10, 10, 10, 10))
-        self.assertEqual(nt[0].dim(), 1)
+        self.assertEqual(nt[0].dim(), 3)
         self.assertEqual(nt[0].size(), (10, 10, 10))
         self.assertEqual(nt[0][0].size(), torch.Size([10, 10]))
         self.assertEqual(nt[0][0][0].size(), torch.Size([10]))
@@ -53,6 +53,7 @@ class TestTensorMask(TestCase):
         self.assertEqual(mask.dim(), 0)
         self.assertEqual(tensor.size(), torch.Size([2, 2]))
         self.assertEqual(tensor.dim(), 2)
+        self.assertEqual(tensor.dim(), nt.dim())
 
         nt = NT.nested_tensor([
             NT.nested_tensor([
@@ -71,25 +72,27 @@ class TestTensorMask(TestCase):
         # mask_dim = None
         tensor, mask = nt.to_tensor_mask()
         self.assertEqual(mask, torch.tensor([[[ True, False]],
-                                             [[ True,  True]]]))
+                                             [[ True, True]]]))
         self.assertEqual(mask.size(), torch.Size([2, 1, 2]))
         self.assertEqual(mask.dim(), 3)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 4)
+        self.assertEqual(tensor.dim(), nt.dim())
 
         # mask_dim = 0
         tensor, mask = nt.to_tensor_mask(mask_dim=0)
         self.assertEqual(mask, torch.tensor([[[ True, False]],
-                                             [[ True,  True]]]))
+                                             [[ True, True]]]))
         self.assertEqual(mask.size(), torch.Size([2, 1, 2]))
         self.assertEqual(mask.dim(), 3)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 4)
+        self.assertEqual(tensor.dim(), nt.dim())
 
         # mask_dim = 1
         tensor, mask = nt.to_tensor_mask(mask_dim=1)
         self.assertEqual(mask, torch.tensor([[[ True, False]],
-                                             [[ True,  True]]]))
+                                             [[ True, True]]]))
         self.assertEqual(mask.size(), torch.Size([2, 1, 2]))
         self.assertEqual(mask.dim(), 3)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
@@ -103,26 +106,29 @@ class TestTensorMask(TestCase):
         self.assertEqual(mask.dim(), 3)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 4)
+        self.assertEqual(tensor.dim(), nt.dim())
 
         # mask_dim = 3
         tensor, mask = nt.to_tensor_mask(mask_dim=3)
         self.assertEqual(mask, torch.tensor([[[ True, False]],
-                                             [[ True,  True]]]))
+                                             [[ True, True]]]))
         self.assertEqual(mask.size(), torch.Size([2, 1, 2]))
         self.assertEqual(mask.dim(), 3)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 4)
+        self.assertEqual(tensor.dim(), nt.dim())
 
         # mask_dim = 4
         tensor, mask = nt.to_tensor_mask(mask_dim=4)
-        self.assertEqual(mask, torch.tensor([[[[ True,  True],
+        self.assertEqual(mask, torch.tensor([[[[ True, True],
                                                [False, False]]],
-                                             [[[ True,  True],
-                                               [ True,  True]]]]))
+                                             [[[ True, True],
+                                               [ True, True]]]]))
         self.assertEqual(mask.size(), torch.Size([2, 1, 2, 2]))
         self.assertEqual(mask.dim(), 4)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 4)
+        self.assertEqual(tensor.dim(), nt.dim())
 
         nt = NT.nested_tensor([
             NT.nested_tensor([
@@ -146,6 +152,7 @@ class TestTensorMask(TestCase):
         self.assertEqual(mask.dim(), 0)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 5)
+        self.assertEqual(tensor.dim(), nt.dim())
 
         # mask_dim = 0
         tensor, mask = nt.to_tensor_mask(mask_dim=0)
@@ -154,6 +161,7 @@ class TestTensorMask(TestCase):
         self.assertEqual(mask.dim(), 0)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 5)
+        self.assertEqual(tensor.dim(), nt.dim())
 
         # mask_dim = 1
         tensor, mask = nt.to_tensor_mask(mask_dim=1)
@@ -162,6 +170,7 @@ class TestTensorMask(TestCase):
         self.assertEqual(mask.dim(), 1)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 5)
+        self.assertEqual(tensor.dim(), nt.dim())
 
         # mask_dim = 2
         tensor, mask = nt.to_tensor_mask(mask_dim=2)
@@ -170,6 +179,7 @@ class TestTensorMask(TestCase):
         self.assertEqual(mask.dim(), 2)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 5)
+        self.assertEqual(tensor.dim(), nt.dim())
 
         # mask_dim = 3
         tensor, mask = nt.to_tensor_mask(mask_dim=3)
@@ -178,6 +188,7 @@ class TestTensorMask(TestCase):
         self.assertEqual(mask.dim(), 3)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 5)
+        self.assertEqual(tensor.dim(), nt.dim())
 
         # mask_dim = 4
         tensor, mask = nt.to_tensor_mask(mask_dim=4)
@@ -186,6 +197,7 @@ class TestTensorMask(TestCase):
         self.assertEqual(mask.dim(), 4)
         self.assertEqual(tensor.size(), torch.Size([2, 1, 1, 2, 2]))
         self.assertEqual(tensor.dim(), 5)
+        self.assertEqual(tensor.dim(), nt.dim())
 
     def test_nested_tensor_from_tensor_mask(self):
         original_nt = NT.nested_tensor([
@@ -203,35 +215,18 @@ class TestTensorMask(TestCase):
             ])
         ])
 
-        # 
-        # mask_dim = 4
-        #
+        expected_nt0 = torch.tensor([[[[[1, 2],
+                                        [3, 4]]]],
+                                     [[[[5, 6],
+                                        [7, 8]]]]])
 
-        # nested_dim = 4
-        tensor, mask = original_nt.to_tensor_mask(mask_dim=4)
-        nt4 = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=4)
-        self.assertEqual(original_nt, nt4)
-
-        # nested_dim = 3
-        nt3 = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=3)
-        expected_nt3 = NT.nested_tensor([
-            NT.nested_tensor([
-                NT.nested_tensor([
-                    torch.tensor([[1, 2],
-                                  [3, 4]]),
-                ]),
-            ]),
-            NT.nested_tensor([
-                NT.nested_tensor([
-                    torch.tensor([[5, 6],
-                                 [7, 8]]),
-                ]),
-            ]),
+        expected_nt1 = NT.nested_tensor([
+            torch.tensor([[[[1, 2],
+                            [3, 4]]]]),
+            torch.tensor([[[[5, 6],
+                            [7, 8]]]]),
         ])
-        self.assertEqual(expected_nt3, nt3)
 
-        # nested_dim = 2
-        nt2 = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
         expected_nt2 = NT.nested_tensor([
             NT.nested_tensor([
                 torch.tensor([[[1, 2],
@@ -242,40 +237,75 @@ class TestTensorMask(TestCase):
                               [7, 8]]]),
             ]),
         ])
-        self.assertEqual(expected_nt2, nt2)
 
-        # nested_dim = 1
-        nt1 = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=1)
-        expected_nt1 = NT.nested_tensor([
-            torch.tensor([[[[1, 2],
-                            [3, 4]]]]),
-            torch.tensor([[[[5, 6],
-                            [7, 8]]]]),
-        ])
-        self.assertEqual(expected_nt1, nt1)
+        #
+        # mask_dim = None
+        #
+        tensor, mask = original_nt.to_tensor_mask()
+        self.assertRaisesRegex(RuntimeError, 
+                               "Mask has to have dimention > 0", 
+                               lambda: NT.nested_tensor_from_tensor_mask(tensor, mask))
 
-        # nested_dim = 0
-        nt0 = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=0)
-        expected_nt0 = torch.tensor([
-                                        [[[[1, 2],
-                                        [3, 4]]]],
-                                        [[[[5, 6],
-                                        [7, 8]]]]
-                                    ])
-        self.assertEqual(expected_nt0, nt0)
+        #
+        # mask_dim = 1
+        #
+        tensor, mask = original_nt.to_tensor_mask(mask_dim = 1)
 
-        # nested_dim = None
-        nt = NT.nested_tensor_from_tensor_mask(tensor, mask)
-        self.assertEqual(expected_nt0, nt)
+        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask)
+        self.assertEqual(expected_nt0, res_nt)
+
+        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=0)
+        self.assertEqual(expected_nt0, res_nt)
+
+        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=1)
+        self.assertEqual(expected_nt1, res_nt)
+
+        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
+        self.assertEqual(expected_nt1, res_nt)
+
+        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=3)
+        self.assertEqual(expected_nt1, res_nt)
+
+        #
+        # mask_dim = 2
+        #
+        tensor, mask = original_nt.to_tensor_mask(mask_dim=2)
+
+        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask)
+        self.assertEqual(expected_nt0, res_nt)
+
+        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=0)
+        self.assertEqual(expected_nt0, res_nt)
+
+        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=1)
+        self.assertEqual(expected_nt1, res_nt)
+
+        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
+        self.assertEqual(expected_nt2, res_nt)
+
+        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=3)
+        self.assertEqual(expected_nt2, res_nt)
+
+        # 
+        # mask_dim = 3
+        #
+        tensor, mask = original_nt.to_tensor_mask(mask_dim=3)
+
+        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask)
+        self.assertEqual(expected_nt0, res_nt)
+        
+        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=0)
+        self.assertEqual(expected_nt0, res_nt)
+
+        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=1)
+        self.assertEqual(expected_nt1, res_nt)
+
+        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
+        self.assertEqual(expected_nt2, res_nt)
+
+        res_nt = NT.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=3)
+        self.assertEqual(original_nt, res_nt)
+
 
 if __name__ == "__main__":
     unittest.main()
-
-
-# TODO: 
-# 1. test cases for all asserts
-# 2. test cases for all errors 
-# 3. test cases for NT from tensor+mask
-# 4. ask if tensor(True) mask + tensor -> NT? its an error now.
-#
-#

--- a/test/test_nested_tensor_masking.py
+++ b/test/test_nested_tensor_masking.py
@@ -27,15 +27,15 @@ class TestTensorMask(TestCase):
         self.assertEqual(nt1[0].dim(), 2)
         self.assertEqual(nested_size_to_list(nt1.nested_size()), [[[2],[2]], [[2],[2]]])
 
-        nt1 = utils.gen_nested_tensor(seed=1, nested_dim=2, tensor_dim=2, size_low=2, size_high=2)
+        nt1 = utils.gen_nested_tensor(seed=3, nested_dim=2, tensor_dim=2, size_low=1, size_high=5)
         self.assertTrue(nt.is_nested_tensor(nt1))
         self.assertEqual(nt1.nested_dim(), 2)
-        self.assertEqual(nt1.size(), (2, 2, 2, 2))
+        self.assertEqual(nt1.size(), (3, 2, None, None))
         self.assertEqual(nt1[0].dim(), 3)
-        self.assertEqual(nt1[0].size(), (2, 2, 2))
-        self.assertEqual(nt1[0][0].size(), torch.Size([2, 2]))
-        self.assertEqual(nt1[0][0][0].size(), torch.Size([2]))
-        self.assertEqual(nested_size_to_list(nt1.nested_size()), [[[2, 2],[2, 2]], [[2, 2],[2, 2]]])
+        self.assertEqual(nt1[0].size(), (2, None, None))
+        self.assertEqual(nt1[0][0].size(), torch.Size([2, 4]))
+        self.assertEqual(nt1[0][0][0].size(), torch.Size([4]))
+        self.assertEqual(nested_size_to_list(nt1.nested_size()), [[[2, 4], [4, 3]], [[2, 4], [4, 3]], [[2, 4], [4, 3]]])
 
     #
     # Group of tests to test to_tensor_mask() 

--- a/test/utils.py
+++ b/test/utils.py
@@ -101,7 +101,7 @@ def gen_nested_list(seed, nested_dim, tensor_dim, size_low=1, size_high=10):
     else:
         for i in range(num_tensors):
             tensors.append(gen_nested_list(
-                num_tensors * seed, nested_dim - 1, tensor_dim))
+                num_tensors * seed, nested_dim - 1, tensor_dim, size_low=size_low, size_high=size_high))
     return tensors
 
 


### PR DESCRIPTION
Methods covered:
- gen_nested_tensor
- to_tensor_mask
- nested_tensor_from_tensor_mask

ToDo:
- cover edge cases
- cover error cases