### PR TITLE
Enabled contiguity check in assertEqual

### DIFF
--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.0.1.dev202011622+5de3fd2'
-git_version = '5de3fd2e150c10f99dea12a381f7db134f1308fe'
+__version__ = '0.0.1.dev202011716+bc96e2e'
+git_version = 'bc96e2e33c2fafd29bca8521d811849ecc673f76'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/test/test_nested_tensor_nary.py
+++ b/test/test_nested_tensor_nary.py
@@ -91,7 +91,7 @@ def _gen_test_unary(func__, nested_dim, device):
         self.assertTrue(a2.nested_dim() == a3.nested_dim())
 
         def _close(t1, t2):
-            self.assertAlmostEqual(t1, t2)
+            self.assertAlmostEqual(t1, t2, ignore_contiguity=True)
 
         if func__ not in ['mvlgamma']:
             func(a1, out=a3)
@@ -116,8 +116,9 @@ def _gen_test_binary(func):
         a2_l = nestedtensor.as_nested_tensor([b.clone(), c.clone()])
         a3 = nestedtensor.nested_tensor([getattr(torch, func)(a, b),
                                   getattr(torch, func)(b, c)])
-        self.assertEqual(a3, getattr(torch, func)(a1_l, a2_l))
-        self.assertEqual(a3, getattr(torch, func)(a1, a2))
+        a3_l = nestedtensor.as_nested_tensor(a3)
+        self.assertEqual(a3_l, getattr(torch, func)(a1_l, a2_l))
+        self.assertEqual(a3_l, getattr(torch, func)(a1, a2))
         self.assertEqual(a3, getattr(a1, func)(a2))
         self.assertEqual(a3, getattr(a1, func + "_")(a2))
         self.assertEqual(a3, a1)

--- a/test/utils_test_case.py
+++ b/test/utils_test_case.py
@@ -182,6 +182,7 @@ class TestCaseBase(unittest.TestCase):
             super(TestCaseBase, self).assertNotEqual(x, y, message)
 
 class TestCase(TestCaseBase):
+    # ToDo: remove ignore_contiguity flag. We should not use it. 
     def assertAlmostEqual(self, x, y, places=None, msg=None, delta=None, allow_inf=None, ignore_contiguity=False):
         prec = delta
         if places:

--- a/test/utils_test_case.py
+++ b/test/utils_test_case.py
@@ -182,7 +182,13 @@ class TestCaseBase(unittest.TestCase):
             super(TestCaseBase, self).assertNotEqual(x, y, message)
 
 class TestCase(TestCaseBase):
-    def assertEqual(self, x, y, prec=None, message='', allow_inf=False):
+    def assertAlmostEqual(self, x, y, places=None, msg=None, delta=None, allow_inf=None, ignore_contiguity=False):
+        prec = delta
+        if places:
+            prec = 10**(-places)
+        self.assertEqual(x, y, prec, msg, allow_inf, ignore_contiguity)
+
+    def assertEqual(self, x, y, prec=None, message='', allow_inf=False, ignore_contiguity=False):
         if not isinstance(x, NT.NestedTensor) and not isinstance(y, NT.NestedTensor):
             super().assertEqual(x, y, prec, message, allow_inf)
         elif not isinstance(x, NT.NestedTensor) or not isinstance(y, NT.NestedTensor):
@@ -212,14 +218,11 @@ class TestCase(TestCaseBase):
             if x.requires_grad != y.requires_grad:
                 self.fail("Nested tensors requires grad properties don't match. {} != {}".format(x.requires_grad, y.requires_grad))
 
-            # TODO: Uncomment once the tests are fixed. 
-            '''
-            if x.is_contiguous() != y.is_contiguous():
+            if not ignore_contiguity and x.is_contiguous() != y.is_contiguous():
                 self.fail("Nested tensors contiguity don't match. {} != {}".format(x.is_contiguous(), y.is_contiguous()))
 
             if x.element_size() != y.element_size():
                 self.fail("Nested tensors element sizes don't match. {} != {}".format(x.element_size(), y.element_size()))
-            '''
 
             if x.size() != y.size():
                 self.fail("Nested tensors sizes don't match. {} != {}".format(x.size(), y.size()))
@@ -232,4 +235,4 @@ class TestCase(TestCaseBase):
             
             for x_, y_ in zip(x, y):
                 self.assertEqual(x_, y_, prec=prec, message=message,
-                                 allow_inf=allow_inf)
+                                 allow_inf=allow_inf, ignore_contiguity=ignore_contiguity)


### PR DESCRIPTION
We need to add `ignore_contiguity` flag due to difference in constructors behavior. 