### PR TITLE
Updated overloads for interpolate and conv2d to expect different arguments.

### DIFF
--- a/nestedtensor/csrc/functions.cpp
+++ b/nestedtensor/csrc/functions.cpp
@@ -93,14 +93,14 @@ NestedTensor dropout(NestedTensor input,
 NestedTensor conv2d(const NestedTensor input, 
                     const at::Tensor weight, 
                     c10::optional<at::Tensor> bias, 
-                    c10::optional<std::vector<int64_t>> stride,
-                    c10::optional<std::vector<int64_t>> padding,
-                    c10::optional<std::vector<int64_t>> dilation,
+                    at::IntArrayRef stride,
+                    at::IntArrayRef padding,
+                    at::IntArrayRef dilation,
                     c10::optional<int64_t> groups) {
   TensorNode structure = input.get_structure();
-  auto options = F::Conv2dFuncOptions().stride(stride.value())
-                                       .padding(padding.value())
-                                       .dilation(dilation.value())
+  auto options = F::Conv2dFuncOptions().stride(stride)
+                                       .padding(padding)
+                                       .dilation(dilation)
                                        .groups(groups.value());
   if (bias.has_value()) {
       options = options.bias(bias.value());

--- a/nestedtensor/csrc/functions.cpp
+++ b/nestedtensor/csrc/functions.cpp
@@ -194,7 +194,7 @@ NestedTensor cross_entropy(NestedTensor input,
 }
 
 NestedTensor interpolate(NestedTensor input,
-                         c10::optional<std::vector<int64_t>> size,
+                         c10::optional<at::IntArrayRef> size,
                          c10::optional<std::vector<double>> scale_factor,
                          c10::optional<std::string> mode,
                          c10::optional<bool> align_corners) {
@@ -221,7 +221,7 @@ NestedTensor interpolate(NestedTensor input,
 
     auto options = F::InterpolateFuncOptions().mode(int_mode);
     if (scale_factor.has_value()) {
-        options.scale_factor() = scale_factor.value();
+        options = options.scale_factor(scale_factor.value());
     }
 
     if (align_corners.has_value()) {
@@ -229,11 +229,7 @@ NestedTensor interpolate(NestedTensor input,
     }
 
     if (size.has_value()) {
-        if (size.value().size() == 2) {
-            options.size() = size.value();
-        } else {
-            options.size() = std::vector<int64_t>({size.value()[0], size.value()[0]});
-        }
+        options = options.size(size.value().vec());
     }
 
     TensorNode res = map(

--- a/nestedtensor/csrc/functions.cpp
+++ b/nestedtensor/csrc/functions.cpp
@@ -195,7 +195,7 @@ NestedTensor cross_entropy(NestedTensor input,
 
 NestedTensor interpolate(NestedTensor input,
                          c10::optional<at::IntArrayRef> size,
-                         c10::optional<std::vector<double>> scale_factor,
+                         c10::optional<at::ArrayRef<double>> scale_factor,
                          c10::optional<std::string> mode,
                          c10::optional<bool> align_corners) {
                          //bool recompute_scale_factor) { // TODO: use
@@ -220,28 +220,20 @@ NestedTensor interpolate(NestedTensor input,
     }
 
     auto options = F::InterpolateFuncOptions().mode(int_mode);
+    if (size.has_value()) {
+      options = options.size(size.value().vec());
+    }
+    
     if (scale_factor.has_value()) {
-        options = options.scale_factor(scale_factor.value());
+      options = options.scale_factor(scale_factor.value().vec());
     }
 
     if (align_corners.has_value()) {
-        options.align_corners() = align_corners.value();
-    }
-
-    if (size.has_value()) {
-        options = options.size(size.value().vec());
+      options.align_corners() = align_corners.value();
     }
 
     TensorNode res = map(
-        [&options, &size, &scale_factor](at::Tensor input_tensor) {
-          // size or scale factor have to be defined
-          if (!size.has_value() && !scale_factor.has_value()) {
-            std::vector<int64_t> sizes;
-            sizes.push_back(input_tensor.unsqueeze(0).size(2));
-            sizes.push_back(input_tensor.unsqueeze(0).size(2));
-            options.size() = sizes;
-          }
-
+        [&options](at::Tensor input_tensor) {
           return F::interpolate(input_tensor.unsqueeze(0), options).squeeze(0);
         },
         input_structure);

--- a/nestedtensor/csrc/functions.h
+++ b/nestedtensor/csrc/functions.h
@@ -51,7 +51,7 @@ NestedTensor cross_entropy(NestedTensor input,
 
 NestedTensor interpolate(NestedTensor input,
                          c10::optional<at::IntArrayRef> size,
-                         c10::optional<std::vector<double>> scale_factor,
+                         c10::optional<at::ArrayRef<double>> scale_factor,
                          c10::optional<std::string> mode,
                          c10::optional<bool> align_corners);
 

--- a/nestedtensor/csrc/functions.h
+++ b/nestedtensor/csrc/functions.h
@@ -50,7 +50,7 @@ NestedTensor cross_entropy(NestedTensor input,
                            c10::optional<std::string> reduction);
 
 NestedTensor interpolate(NestedTensor input,
-                         c10::optional<std::vector<int64_t>> size,
+                         c10::optional<at::IntArrayRef> size,
                          c10::optional<std::vector<double>> scale_factor,
                          c10::optional<std::string> mode,
                          c10::optional<bool> align_corners);

--- a/nestedtensor/csrc/functions.h
+++ b/nestedtensor/csrc/functions.h
@@ -9,17 +9,20 @@ NestedTensor squeeze(NestedTensor input, c10::optional<int64_t> dim,
         c10::optional<NestedTensor> out);
 
 NestedTensor relu(NestedTensor input, c10::optional<bool> inplace); 
+
 NestedTensor relu_out(NestedTensor& input);
+
 NestedTensor dropout(NestedTensor input, 
                      c10::optional<double> p, 
                      c10::optional<bool> training, 
                      c10::optional<bool> inplace);
+
 NestedTensor conv2d(NestedTensor input, 
                     const at::Tensor weight, 
                     c10::optional<at::Tensor> bias, 
-                    c10::optional<std::vector<int64_t>> stride,
-                    c10::optional<std::vector<int64_t>> padding,
-                    c10::optional<std::vector<int64_t>> dilation,
+                    at::IntArrayRef stride,
+                    at::IntArrayRef padding,
+                    at::IntArrayRef dilation,
                     c10::optional<int64_t> groups);
 
 NestedTensor max_pool2d(NestedTensor input,

--- a/nestedtensor/csrc/python_args.h
+++ b/nestedtensor/csrc/python_args.h
@@ -32,12 +32,7 @@ struct type_caster<THPArrayRef<T>> {
    */
   bool load(handle obj, bool) {
     /* Extract PyObject from handle */
-    if (py::isinstance<py::int_>(obj)) {
-      value.val.push_back(py::cast<T>(obj));
-      value.is_list = false;
-      return true;
-    }
-    if (py::isinstance<py::float_>(obj)) {
+    if (py::isinstance<py::int_>(obj) || py::isinstance<py::float_>(obj)) {
       value.val.push_back(py::cast<T>(obj));
       value.is_list = false;
       return true;

--- a/nestedtensor/csrc/python_functions.cpp
+++ b/nestedtensor/csrc/python_functions.cpp
@@ -184,47 +184,18 @@ void add_functions(
         py::arg("ignore_index") = -100,
         py::arg("reduce") = true,
         py::arg("reduction") = "mean");
-  
-    m.def("interpolate", 
-        [](THPNestedTensor input,
-           c10::optional<int64_t> size,
-           c10::optional<std::vector<double>> scale_factor,
-           c10::optional<std::string> mode,
-           c10::optional<bool> align_corners,
-           c10::optional<bool> recompute_scale_factor) {
-             if (size.has_value()) {
-               std::vector<int64_t> sz {size.value(), size.value()};
-               return THPNestedTensor(interpolate(input.data().contiguous(), 
-                                                sz,
-                                                scale_factor, 
-                                                mode,
-                                                align_corners));
-             }
-
-             return THPNestedTensor(interpolate(input.data().contiguous(), 
-                                                c10::nullopt,
-                                                scale_factor, 
-                                                mode,
-                                                align_corners));
-        },
-        py::arg("input"),
-        py::arg("size") = nullptr,
-        py::arg("scale_factor") = nullptr,
-        py::arg("mode") = "nearest",
-        py::arg("align_corners") = false,
-        py::arg("recompute_scale_factor") = false);
 
   m.def("interpolate", 
         [](THPNestedTensor input,
-           c10::optional<std::vector<int64_t>> size,
+           c10::optional<IAR> size,
            c10::optional<std::vector<double>> scale_factor,
            c10::optional<std::string> mode,
            c10::optional<bool> align_corners,
            c10::optional<bool> recompute_scale_factor) {
              if (size.has_value()) {
                return THPNestedTensor(interpolate(input.data().contiguous(), 
-                                                  size.value(),
-                                                  scale_factor, 
+                                                  size.value().extract<2>(),
+                                                  c10::nullopt, 
                                                   mode,
                                                   align_corners));
              }

--- a/nestedtensor/csrc/python_functions.cpp
+++ b/nestedtensor/csrc/python_functions.cpp
@@ -85,9 +85,9 @@ void add_functions(
         [](THPNestedTensor input, 
            const at::Tensor weight, 
            c10::optional<at::Tensor> bias, 
-           IAR<int64_t> stride,
-           IAR<int64_t> padding,
-           IAR<int64_t> dilation,
+           THPArrayRef<int64_t> stride,
+           THPArrayRef<int64_t> padding,
+           THPArrayRef<int64_t> dilation,
            c10::optional<int64_t> group) {
              return THPNestedTensor(conv2d(input.data().contiguous(), 
                                            weight, 
@@ -108,10 +108,10 @@ void add_functions(
   m.def(
       "max_pool2d",
       [](THPNestedTensor input,
-         IAR<int64_t> kernel_size,
-         IAR<int64_t> stride,
-         IAR<int64_t> padding,
-         IAR<int64_t> dilation,
+         THPArrayRef<int64_t> kernel_size,
+         THPArrayRef<int64_t> stride,
+         THPArrayRef<int64_t> padding,
+         THPArrayRef<int64_t> dilation,
          bool return_indices,
          bool ceil_mode) {
         if (return_indices) {
@@ -187,8 +187,8 @@ void add_functions(
 
   m.def("interpolate", 
         [](THPNestedTensor input,
-           c10::optional<IAR<int64_t>> size,
-           c10::optional<IAR<double>> scale_factor,
+           c10::optional<THPArrayRef<int64_t>> size,
+           c10::optional<THPArrayRef<double>> scale_factor,
            c10::optional<std::string> mode,
            c10::optional<bool> align_corners,
            c10::optional<bool> recompute_scale_factor) {

--- a/nestedtensor/csrc/python_functions.cpp
+++ b/nestedtensor/csrc/python_functions.cpp
@@ -85,9 +85,9 @@ void add_functions(
         [](THPNestedTensor input, 
            const at::Tensor weight, 
            c10::optional<at::Tensor> bias, 
-           IAR stride,
-           IAR padding,
-           IAR dilation,
+           IAR<int64_t> stride,
+           IAR<int64_t> padding,
+           IAR<int64_t> dilation,
            c10::optional<int64_t> group) {
              return THPNestedTensor(conv2d(input.data().contiguous(), 
                                            weight, 
@@ -108,10 +108,10 @@ void add_functions(
   m.def(
       "max_pool2d",
       [](THPNestedTensor input,
-         IAR kernel_size,
-         IAR stride,
-         IAR padding,
-         IAR dilation,
+         IAR<int64_t> kernel_size,
+         IAR<int64_t> stride,
+         IAR<int64_t> padding,
+         IAR<int64_t> dilation,
          bool return_indices,
          bool ceil_mode) {
         if (return_indices) {
@@ -187,8 +187,8 @@ void add_functions(
 
   m.def("interpolate", 
         [](THPNestedTensor input,
-           c10::optional<IAR> size,
-           c10::optional<std::vector<double>> scale_factor,
+           c10::optional<IAR<int64_t>> size,
+           c10::optional<IAR<double>> scale_factor,
            c10::optional<std::string> mode,
            c10::optional<bool> align_corners,
            c10::optional<bool> recompute_scale_factor) {
@@ -200,11 +200,15 @@ void add_functions(
                                                   align_corners));
              }
 
-             return THPNestedTensor(interpolate(input.data().contiguous(), 
-                                                c10::nullopt,
-                                                scale_factor, 
-                                                mode,
-                                                align_corners));
+             if (scale_factor.has_value()) {
+               return THPNestedTensor(interpolate(input.data().contiguous(), 
+                                                  c10::nullopt,
+                                                  scale_factor.value().extract<2>(), 
+                                                  mode,
+                                                  align_corners));
+             }
+
+             throw "Either size or scale factor have to be passed.";
         },
         py::arg("input"),
         py::arg("size") = nullptr,

--- a/nestedtensor/csrc/python_functions.cpp
+++ b/nestedtensor/csrc/python_functions.cpp
@@ -85,16 +85,16 @@ void add_functions(
         [](THPNestedTensor input, 
            const at::Tensor weight, 
            c10::optional<at::Tensor> bias, 
-           c10::optional<std::vector<int64_t>> stride,
-           c10::optional<std::vector<int64_t>> padding,
-           c10::optional<std::vector<int64_t>> dilation,
+           IAR stride,
+           IAR padding,
+           IAR dilation,
            c10::optional<int64_t> group) {
              return THPNestedTensor(conv2d(input.data().contiguous(), 
                                            weight, 
                                            bias, 
-                                           stride, 
-                                           padding, 
-                                           dilation, 
+                                           stride.extract<2>(), 
+                                           padding.extract<2>(),
+                                           dilation.extract<2>(),
                                            group));
            },
         py::arg("input"), 
@@ -132,35 +132,6 @@ void add_functions(
       py::arg("padding") = std::vector<int64_t>({0, 0}),
       py::arg("dilation") = std::vector<int64_t>({1, 1}),
       py::arg("return_indices") = false, // TODO Add overload and kernel
-      py::arg("ceil_mode") = false);
-
-  m.def(
-      "max_pool2d",
-      [](THPNestedTensor input,
-         IAR kernel_size,
-         IAR stride,
-         IAR padding,
-         IAR dilation,
-         bool return_indices,
-         bool ceil_mode) {
-        if (return_indices) {
-          throw std::invalid_argument(
-              "max_pool2d currently doesn't support returning indices.");
-        }
-        return THPNestedTensor(max_pool2d(
-            input.data().contiguous(),
-            kernel_size.extract<2>(),
-            stride.extract<2>(),
-            padding.extract<2>(),
-            dilation.extract<2>(),
-            ceil_mode));
-      },
-      py::arg("input"),
-      py::arg("kernel_size"),
-      py::arg("stride") = std::vector<int64_t>({}),
-      py::arg("padding") = std::vector<int64_t>({0, 0}),
-      py::arg("dilation") = std::vector<int64_t>({1, 1}),
-      py::arg("return_indices") = false,
       py::arg("ceil_mode") = false);
 
   m.def("batch_norm", 
@@ -214,7 +185,7 @@ void add_functions(
         py::arg("reduce") = true,
         py::arg("reduction") = "mean");
   
-  m.def("interpolate", 
+    m.def("interpolate", 
         [](THPNestedTensor input,
            c10::optional<int64_t> size,
            c10::optional<std::vector<double>> scale_factor,

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.0.1.dev202041018+103126f'
-git_version = '103126f48c7255ef4aec863e4d9f9ba68e5f933e'
+__version__ = '0.0.1.dev202041018+2074ab8'
+git_version = '2074ab8e7ade3c4a963d30065217d15046017fa1'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.0.1.dev202041018+2074ab8'
-git_version = '2074ab8e7ade3c4a963d30065217d15046017fa1'
+__version__ = '0.0.1.dev202041018+14819da'
+git_version = '14819da098e6943f3de76527340ea0357ae7efdd'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.0.1.dev20204918+2bb3c06'
-git_version = '2bb3c06d913db2d8b29f77b0a9aa88737444bf92'
+__version__ = '0.0.1.dev202041018+103126f'
+git_version = '103126f48c7255ef4aec863e4d9f9ba68e5f933e'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/test/test_nested_tensor_functional.py
+++ b/test/test_nested_tensor_functional.py
@@ -241,11 +241,11 @@ class TestFunctional(TestCase):
         # no optional params
         tensor_res = []
         for i in range(2):
-            t_res = torch.nn.functional.interpolate(inputs[i].unsqueeze(0).contiguous(), inputs[i].unsqueeze(0).shape[-2])
+            t_res = torch.nn.functional.interpolate(inputs[i].unsqueeze(0).contiguous(), 200)
             tensor_res.append(t_res.squeeze(0))
 
         for nt in [nestedtensor.nested_tensor(inputs), nestedtensor.as_nested_tensor(inputs)]:
-            nt_res = torch.nn.functional.interpolate(nt)
+            nt_res = torch.nn.functional.interpolate(nt, 200)
             self.assertEqual(nestedtensor.nested_tensor(tensor_res), nt_res)
 
         # tuple/int size and optional mode
@@ -260,8 +260,8 @@ class TestFunctional(TestCase):
                 self.assertEqual(nestedtensor.nested_tensor(tensor_res), nt_res)
 
         # scale_factor instead of a size
-        tensor_res = []
-        for scale_factor in [(2.2, 2.2)]:
+        for scale_factor in [(2.2, 2.2), 1.1]:
+            tensor_res = []
             for i in range(2):
                 t_res = torch.nn.functional.interpolate(inputs[i].unsqueeze(0).contiguous(), scale_factor=scale_factor)
                 tensor_res.append(t_res.squeeze(0))

--- a/test/test_nested_tensor_functional.py
+++ b/test/test_nested_tensor_functional.py
@@ -31,7 +31,7 @@ class TestFunctional(TestCase):
         ]
 
         # most of optional params
-        conv2d = torch.nn.Conv2d(3, 33, kernel_size=(3, 5), stride=(2, 1), padding=(4, 2), padding_mode='zeros', dilation=(3, 1), groups=1, bias=True)
+        conv2d = torch.nn.Conv2d(3, 33, kernel_size=3, stride=(2, 1), padding=(4, 2), padding_mode='zeros', dilation=1, groups=1, bias=True)
         tensor_res = []
         for i in range(2):
             t_res = conv2d(inputs[i].unsqueeze(0).contiguous())
@@ -42,7 +42,7 @@ class TestFunctional(TestCase):
             self.assertEqual(nestedtensor.nested_tensor(tensor_res), nt_res)
 
         # some of optional params
-        conv2d = torch.nn.Conv2d(3, 33, kernel_size=(3, 5), bias=False)
+        conv2d = torch.nn.Conv2d(3, 33, kernel_size=3, bias=False)
         tensor_res = []
         for i in range(2):
             t_res = conv2d(inputs[i].unsqueeze(0).contiguous())
@@ -65,9 +65,9 @@ class TestFunctional(TestCase):
             self.assertEqual(nt_res, tensor_res)
 
         # optional params with no bias
-        tensor_res = [torch.nn.functional.conv2d(t.unsqueeze(0), weight, None, (2, 2), (3, 3), (1, 1), 1).squeeze(0) for t in inputs]
+        tensor_res = [torch.nn.functional.conv2d(t.unsqueeze(0), weight, None, 2, 3, 1, 1).squeeze(0) for t in inputs]
         for nt in [nestedtensor.nested_tensor(inputs), nestedtensor.as_nested_tensor(inputs)]:
-            nt_res = [t for t in torch.nn.functional.conv2d(nt, weight, None, (2, 2), (3, 3), (1, 1), 1).unbind()]
+            nt_res = [t for t in torch.nn.functional.conv2d(nt, weight, None, 2, 3, 1, 1).unbind()]
             self.assertEqual(nt_res, tensor_res)
 
         # optional params with bias
@@ -238,7 +238,7 @@ class TestFunctional(TestCase):
             torch.randn(3, 300, 400)
         ]
 
-         # no optional params
+        # no optional params
         tensor_res = []
         for i in range(2):
             t_res = torch.nn.functional.interpolate(inputs[i].unsqueeze(0).contiguous(), inputs[i].unsqueeze(0).shape[-2])
@@ -257,6 +257,17 @@ class TestFunctional(TestCase):
 
             for nt in [nestedtensor.nested_tensor(inputs), nestedtensor.as_nested_tensor(inputs)]:
                 nt_res = torch.nn.functional.interpolate(nt, size, mode='bilinear', align_corners=True)
+                self.assertEqual(nestedtensor.nested_tensor(tensor_res), nt_res)
+
+        # scale_factor instead of a size
+        tensor_res = []
+        for scale_factor in [(2, 2)]:
+            for i in range(2):
+                t_res = torch.nn.functional.interpolate(inputs[i].unsqueeze(0).contiguous(), scale_factor=scale_factor)
+                tensor_res.append(t_res.squeeze(0))
+
+            for nt in [nestedtensor.nested_tensor(inputs), nestedtensor.as_nested_tensor(inputs)]:
+                nt_res = torch.nn.functional.interpolate(nt, scale_factor=scale_factor)
                 self.assertEqual(nestedtensor.nested_tensor(tensor_res), nt_res)
 
     def test_copy_(self):

--- a/test/test_nested_tensor_functional.py
+++ b/test/test_nested_tensor_functional.py
@@ -261,7 +261,7 @@ class TestFunctional(TestCase):
 
         # scale_factor instead of a size
         tensor_res = []
-        for scale_factor in [(2, 2)]:
+        for scale_factor in [(2.2, 2.2)]:
             for i in range(2):
                 t_res = torch.nn.functional.interpolate(inputs[i].unsqueeze(0).contiguous(), scale_factor=scale_factor)
                 tensor_res.append(t_res.squeeze(0))


### PR DESCRIPTION
For interpolate and conv2d there are arguments that can be passed as a single value or a tuple. This PR enables this behavior for NT.