### PR TITLE
initial benchmarking for segmentation pipeline 

### DIFF
--- a/benchmarks/segmentation_layers.py
+++ b/benchmarks/segmentation_layers.py
@@ -18,12 +18,13 @@ class SegLayersBenchMark(object):
         for h_var in self.args.HV:  
             for w_var in self.args.WV:
                 for seed in self.args.seed:
-                    print("\nHV: ", h_var, " WV: ", w_var, " Seed: ", seed)
                     for layer in self.args.layers:
                         benchmark = getattr(self, layer)
                         self.inputs, self.targets = self.get_input(h_var, w_var, seed)
-                        
-                        print(utils.benchmark_fn(benchmark(), warmup=self.args.warm))
+
+                        result = utils.benchmark_fn(benchmark(), warmup=self.args.warm)
+                        print(result['name'], ",", result['avg_us'], ",", result['std_us'], ",", result['runs'], ",", h_var, ",", w_var, ",", seed)
+
 
     def get_max_size(self, obj, res=None):
         if res is None:

--- a/benchmarks/segmentation_layers.py
+++ b/benchmarks/segmentation_layers.py
@@ -1,11 +1,109 @@
 import torch
 import nestedtensor
 import utils
+import torch.nn.functional as F
 
 N = 6
 C = 30
 H = 500
 W = 600
+
+N1 = 3
+C1 = 30
+H1 = 100
+W1 = 200
+
+N2 = 3
+C2 = 30
+H2 = 400
+W2 = 800
+
+N3 = 3
+C3 = 30
+H3 = 1000
+W3 = 2000
+
+WARM = 2.0
+
+def get_max_size(obj, res=None):
+    if res is None:
+        res = [1]
+
+    if isinstance(obj, list) or isinstance(obj, tuple):
+        for o in obj:
+            res = get_max_size(o, res)
+
+    if isinstance(obj, nestedtensor.nested.nested.NestedTensor):
+        tres = get_max_size(obj.unbind())
+        while len(tres) > len(res):
+                res.append(0)
+
+        res = [max(i, j) for (i, j) in zip(res, tres)]
+
+    if isinstance(obj, torch.Tensor):
+        # scalar
+        if obj.dim() == 0 and obj.numel() == 1:
+            res = [1]
+        else:
+            while len(obj.size()) > len(res):
+                res.append(0)
+
+            res = [max(i, j) for (i, j) in zip(res, obj.size())]
+
+    return res
+
+def pad_tensor_to_shape(t, goal_shape):
+    padd = ()
+    tup = tuple(t.size())
+    assert(t.dim() == len(goal_shape))
+    for i in range(len(tup)):
+        padd = (0, goal_shape[i] - tup[i]) + padd
+    new_tensor = F.pad(t, padd)
+    new_tensor = new_tensor.reshape(goal_shape)
+    return new_tensor
+
+def pad_tensors_to_max_shape(inputs):
+    max_shape = get_max_size(inputs)
+    padded_inputs = [pad_tensor_to_shape(t, max_shape) for t in inputs]
+    return padded_inputs
+
+def get_input_small_diff(pad=False):
+    inputs = [torch.randn(C1, H1, W1) for _ in range(N1)]
+    inputs2 = [torch.randn(C2, H2, W2) for _ in range(N2)]
+    inputs = inputs + inputs2
+
+    if pad:
+        return pad_tensors_to_max_shape(inputs)
+    return inputs
+
+def get_input_big_diff(pad=False):
+    inputs = [torch.randn(C1, H1, W1) for _ in range(N1)]
+    inputs2 = [torch.randn(C3, H3, W3) for _ in range(N3)]
+    inputs = inputs + inputs2
+
+    if pad: 
+        return pad_tensors_to_max_shape(inputs)
+    return inputs
+
+def get_targets_small_diff(pad = False):
+    targets = [torch.randint(1, (H1, W1), dtype=torch.int64) for _ in range(N1)]
+    targets2 = [torch.randint(1, (H2, W2), dtype=torch.int64) for _ in range(N2)]
+    trg = targets + targets2
+
+    if pad: 
+        return pad_tensors_to_max_shape(trg)
+
+    return trg
+
+def get_targets_big_diff(pad = False):
+    targets = [torch.randint(1, (H1, W1), dtype=torch.int64) for _ in range(N1)]
+    targets2 = [torch.randint(1, (H3, W3), dtype=torch.int64) for _ in range(N3)]
+    trg = targets + targets2
+
+    if pad: 
+        return pad_tensors_to_max_shape(trg)
+
+    return trg
 
 #
 # relu
@@ -26,34 +124,137 @@ def relu_nt_tensors_same_size():
     
     return _relu_nt
 
+def relu_tensor_small_diff_pad():
+    inputs = get_input_small_diff(pad=True)
+    stack = torch.stack(inputs)
+
+    def _relu_tensor_small_diff_pad():
+        torch.nn.functional.relu(stack)
+    return _relu_tensor_small_diff_pad
+
+def relu_tensor_small_diff_iter():
+    inputs = get_input_small_diff()
+
+    def _relu_tensor_small_diff_iter():
+        for t in inputs:
+            torch.nn.functional.relu(t)
+    return _relu_tensor_small_diff_iter
+
+def relu_nt_small_diff():
+    inputs = get_input_small_diff()
+    nt = nestedtensor.nested_tensor(inputs)
+
+    def _relu_nt_small_diff():
+        torch.nn.functional.relu(nt)
+
+    return _relu_nt_small_diff
+
+def relu_tensor_big_diff_pad():
+    inputs = get_input_big_diff(pad=True)
+    stack = torch.stack(inputs)
+
+    def _relu_tensor_big_diff_pad():
+        torch.nn.functional.relu(stack)
+    return _relu_tensor_big_diff_pad
+
+def relu_tensor_big_diff_iter():
+    inputs = get_input_big_diff()
+
+    def _relu_tensor_big_diff_iter():
+        for t in inputs:
+            torch.nn.functional.relu(t)
+    return _relu_tensor_big_diff_iter
+
+def relu_nt_big_diff():
+    inputs = get_input_big_diff()
+    nt = nestedtensor.nested_tensor(inputs)
+
+    def _relu_nt_big_diff():
+        torch.nn.functional.relu(nt)
+
+    return _relu_nt_big_diff
+
+
 #
 # conv2d
 #
+conv2d = torch.nn.Conv2d(30, 33, kernel_size= (3, 5), bias=False)
+
 def conv2d_tensor_tensors_same_size():
     inputs = [torch.randn(C, H, W) for _ in range(N)]
     a = torch.stack(inputs)
-    conv2d = torch.nn.Conv2d(30, 33, kernel_size=(3, 5), bias=False)
 
-    def _conv2d_tensor():
+    def _conv2d_tensor_tensors_same_size():
         conv2d(a)
-    return _conv2d_tensor
+    return _conv2d_tensor_tensors_same_size
 
 def conv2d_nt_tensors_same_size():
     inputs = [torch.randn(C, H, W) for _ in range(N)]
-    conv2d = torch.nn.Conv2d(30, 33, kernel_size=(3, 5), bias=False)
     nt = nestedtensor.nested_tensor(inputs)
-    def _conv2d_nt():
+    def _conv2d_nt_tensors_same_size():
         conv2d(nt)
+
+    return _conv2d_nt_tensors_same_size
+
+def conv2d_tensor_small_diff_pad():
+    inputs = get_input_small_diff(pad=True)
+    stack = torch.stack(inputs)
     
-    return _conv2d_nt
+    def _conv2d_tensor_small_diff_pad():
+        conv2d(stack)
+    return _conv2d_tensor_small_diff_pad
+
+def conv2d_tensor_small_diff_iter():
+    inputs = get_input_small_diff()
+    
+    def _conv2d_tensor_small_diff_iter():
+        for t in inputs:
+            conv2d(t.unsqueeze(0)).squeeze(0)
+    return _conv2d_tensor_small_diff_iter
+
+def conv2d_nt_small_diff():
+    inputs = get_input_small_diff()
+    nt = nestedtensor.nested_tensor(inputs)
+
+    def _conv2d_nt_small_diff():
+        conv2d(nt)
+
+    return _conv2d_nt_small_diff
+
+def conv2d_tensor_big_diff_pad():
+    inputs = get_input_big_diff(pad=True)
+    stack = torch.stack(inputs)
+
+    def _conv2d_tensor_big_diff_pad():
+        conv2d(stack)
+    return _conv2d_tensor_big_diff_pad
+
+def conv2d_tensor_big_diff_iter():
+    inputs = get_input_big_diff()
+
+    def _conv2d_tensor_big_diff_iter():
+        for t in inputs:
+            conv2d(t.unsqueeze(0)).squeeze(0)
+    return _conv2d_tensor_big_diff_iter
+
+def conv2d_nt_big_diff():
+    inputs = get_input_big_diff()
+    nt = nestedtensor.nested_tensor(inputs)
+
+    def _conv2d_nt_big_diff():
+        conv2d(nt)
+
+    return _conv2d_nt_big_diff
+
 
 #
 # batch_norm
 #
+batch_norm = torch.nn.BatchNorm2d(30, 1e-05, 0.1)
+
 def batch_norm_tensor_tensors_same_size():
     inputs = [torch.randn(C, H, W) for _ in range(N)]
     a = torch.stack(inputs)
-    batch_norm = torch.nn.BatchNorm2d(30, 1e-05, 0.1)
     batch_norm.eval()
 
     def _batch_norm_tensor():
@@ -63,7 +264,6 @@ def batch_norm_tensor_tensors_same_size():
 def batch_norm_nt_tensors_same_size():
     inputs = [torch.randn(C, H, W) for _ in range(N)]
     nt = nestedtensor.nested_tensor(inputs)
-    batch_norm = torch.nn.BatchNorm2d(30, 1e-05, 0.1)
     batch_norm.eval()
 
     def _batch_norm_nt():
@@ -71,30 +271,138 @@ def batch_norm_nt_tensors_same_size():
     
     return _batch_norm_nt
 
+def batch_norm_tensor_small_diff_pad():
+    inputs = get_input_small_diff(pad=True)
+    stack = torch.stack(inputs)
+    batch_norm.eval()
+
+    def _batch_norm_tensor_small_diff_pad():
+        batch_norm(stack)
+    return _batch_norm_tensor_small_diff_pad
+
+def batch_norm_tensor_small_diff_iter():
+    inputs = get_input_small_diff()
+    batch_norm.eval()
+
+    def _batch_norm_tensor_small_diff_iter():
+        for t in inputs:
+            batch_norm(t.unsqueeze(0)).squeeze(0)
+    return _batch_norm_tensor_small_diff_iter
+
+def batch_norm_nt_small_diff():
+    inputs = get_input_small_diff()
+    nt = nestedtensor.nested_tensor(inputs)
+    batch_norm.eval()
+
+    def _batch_norm_nt_small_diff():
+        batch_norm(nt)
+
+    return _batch_norm_nt_small_diff
+
+def batch_norm_tensor_big_diff_pad():
+    inputs = get_input_big_diff(pad=True)
+    stack = torch.stack(inputs)
+    batch_norm.eval()
+
+    def _batch_norm_tensor_big_diff_pad():
+        batch_norm(stack)
+    return _batch_norm_tensor_big_diff_pad
+
+def batch_norm_tensor_big_diff_iter():
+    inputs = get_input_big_diff()
+    batch_norm.eval()
+
+    def _batch_norm_tensor_big_diff_iter():
+        for t in inputs:
+            batch_norm(t.unsqueeze(0)).squeeze(0)
+    return _batch_norm_tensor_big_diff_iter
+
+def batch_norm_nt_big_diff():
+    inputs = get_input_big_diff()
+    nt = nestedtensor.nested_tensor(inputs)
+    batch_norm.eval()
+
+    def _batch_norm_nt_big_diff():
+        batch_norm(nt)
+
+    return _batch_norm_nt_big_diff
+
 #
 # max_pool2d
 #
+max_pool2d = torch.nn.MaxPool2d(kernel_size=(2, 2), stride=(2, 2), padding=(0, 0), dilation=(1, 1))
+
 def max_pool2d_tensor_tensors_same_size():
     inputs = [torch.randn(C, H, W) for _ in range(N)]
     a = torch.stack(inputs)
-    maxPool2d = torch.nn.MaxPool2d(30)
 
     def _max_pool2d_tensor():
-        maxPool2d(a)
+        max_pool2d(a)
     return _max_pool2d_tensor
 
 def max_pool2d_nt_tensors_same_size():
     inputs = [torch.randn(C, H, W) for _ in range(N)]
-    maxPool2d = torch.nn.MaxPool2d(30)
     nt = nestedtensor.nested_tensor(inputs)
+
     def _max_pool2d_nt():
-        maxPool2d(nt)
+        max_pool2d(nt)
 
     return _max_pool2d_nt
+
+def max_pool2d_tensor_small_diff_pad():
+    inputs = get_input_small_diff(pad=True)
+    stack = torch.stack(inputs)
+    
+    def _max_pool2d_tensor_small_diff_pad():
+        max_pool2d(stack)
+    return _max_pool2d_tensor_small_diff_pad
+
+def max_pool2d_tensor_small_diff_iter():
+    inputs = get_input_small_diff()
+
+    def _max_pool2d_tensor_small_diff_iter():
+        for t in inputs:
+            max_pool2d(t)
+    return _max_pool2d_tensor_small_diff_iter
+
+def max_pool2d_nt_small_diff():
+    inputs = get_input_small_diff()
+    nt = nestedtensor.nested_tensor(inputs)
+
+    def _max_pool2d_nt_small_diff():
+        max_pool2d(nt)
+
+    return _max_pool2d_nt_small_diff
+
+def max_pool2d_tensor_big_diff_pad():
+    inputs = get_input_big_diff(pad=True)
+    stack = torch.stack(inputs)
+
+    def _max_pool2d_tensor_big_diff_pad():
+        max_pool2d(stack)
+    return _max_pool2d_tensor_big_diff_pad
+
+def max_pool2d_tensor_big_diff_iter():
+    inputs = get_input_big_diff()
+
+    def _max_pool2d_tensor_big_diff_iter():
+        for t in inputs:
+            max_pool2d(t)
+    return _max_pool2d_tensor_big_diff_iter
+
+def max_pool2d_nt_big_diff():
+    inputs = get_input_big_diff()
+    nt = nestedtensor.nested_tensor(inputs)
+
+    def _max_pool2d_nt_big_diff():
+        max_pool2d(nt)
+
+    return _max_pool2d_nt_big_diff
 
 #
 # cross_entropy
 #
+cross_entropy = torch.nn.functional.cross_entropy
 def cross_entropy_tensor_tensors_same_size():
     inputs = [torch.randn(C, H, W) for _ in range(N)]
     targets = [torch.randint(1, (H, W), dtype=torch.int64) for _ in range(N)]
@@ -104,7 +412,7 @@ def cross_entropy_tensor_tensors_same_size():
     
 
     def _cross_entropy_tensor():
-        torch.nn.functional.cross_entropy(a, b)
+        cross_entropy(a, b)
     return _cross_entropy_tensor
 
 def cross_entropy_nt_tensors_same_size():
@@ -115,61 +423,281 @@ def cross_entropy_nt_tensors_same_size():
     b = nestedtensor.nested_tensor(targets)
 
     def _cross_entropy_nt():
-        torch.nn.functional.cross_entropy(a, b)
+        cross_entropy(a, b)
     return _cross_entropy_nt
+
+def cross_entropy_tensor_small_diff_pad():
+    inputs = get_input_small_diff(pad=True)
+    targets = get_targets_small_diff(pad=True)
+
+    a = torch.stack(inputs)
+    b = torch.stack(targets)
+
+    def _cross_entropy_tensor_small_diff_pad():
+        cross_entropy(a, b)
+    return _cross_entropy_tensor_small_diff_pad
+
+def cross_entropy_tensor_small_diff_iter():
+    inputs = get_input_small_diff()
+    targets = get_targets_small_diff()
+
+    def _cross_entropy_tensor_small_diff_iter():
+        for a, b in zip(inputs, targets):
+            cross_entropy(a.unsqueeze(0), b.unsqueeze(0)).squeeze(0)
+    return _cross_entropy_tensor_small_diff_iter
+
+def cross_entropy_nt_small_diff():
+    inputs = get_input_small_diff()
+    targets = get_targets_small_diff()
+
+    nt_input = nestedtensor.nested_tensor(inputs)
+    nt_target = nestedtensor.nested_tensor(targets)
+
+    def _cross_entropy_nt_small_diff():
+        cross_entropy(nt_input, nt_target)
+
+    return _cross_entropy_nt_small_diff
+
+def cross_entropy_tensor_big_diff_pad():
+    inputs = get_input_big_diff(pad=True)
+    targets = get_targets_big_diff(pad=True)
+
+    a = torch.stack(inputs)
+    b = torch.stack(targets)
+
+    def _cross_entropy_tensor_big_diff_pad():
+        cross_entropy(a, b)
+    return _cross_entropy_tensor_big_diff_pad
+
+def cross_entropy_tensor_big_diff_iter():
+    inputs = get_input_big_diff()
+    targets = get_targets_big_diff()
+
+    def _cross_entropy_tensor_big_diff_iter():
+        for a, b in zip(inputs, targets):
+            cross_entropy(a.unsqueeze(0), b.unsqueeze(0)).squeeze(0)
+    return _cross_entropy_tensor_big_diff_iter
+
+def cross_entropy_nt_big_diff():
+    inputs = get_input_big_diff()
+    targets = get_targets_big_diff()
+    
+    nt_input = nestedtensor.nested_tensor(inputs)
+    nt_target = nestedtensor.nested_tensor(targets)
+
+    def _cross_entropy_nt_big_diff():
+        cross_entropy(nt_input, nt_target)
+
+    return _cross_entropy_nt_big_diff
 
 #
 # dropout
 #
+dropout = torch.nn.functional.dropout
+
 def dropout_tensor_tensors_same_size():
     inputs = [torch.randn(C, H, W) for _ in range(N)]
     a = torch.stack(inputs)
 
     def _dropout_tensor():
-        torch.nn.functional.dropout(a)
+        dropout(a)
     return _dropout_tensor
 
 def dropout_nt_tensors_same_size():
     inputs = [torch.randn(C, H, W) for _ in range(N)]
     nt = nestedtensor.nested_tensor(inputs)
     def _dropout_nt():
-        torch.nn.functional.dropout(nt)
-    
+        dropout(nt)
+
     return _dropout_nt
+
+def dropout_tensor_small_diff_pad():
+    inputs = get_input_small_diff(pad=True)
+    stack = torch.stack(inputs)
+    
+    def _dropout_tensor_small_diff_pad():
+        dropout(stack)
+    return _dropout_tensor_small_diff_pad
+
+def dropout_tensor_small_diff_iter():
+    inputs = get_input_small_diff()
+    
+    def _dropout_tensor_small_diff_iter():
+        for t in inputs:
+            dropout(t.unsqueeze(0)).squeeze(0)
+    return _dropout_tensor_small_diff_iter
+
+def dropout_nt_small_diff():
+    inputs = get_input_small_diff()
+    nt = nestedtensor.nested_tensor(inputs)
+
+    def _dropout_nt_small_diff():
+        dropout(nt)
+
+    return _dropout_nt_small_diff
+
+def dropout_tensor_big_diff_pad():
+    inputs = get_input_big_diff(pad=True)
+    stack = torch.stack(inputs)
+
+    def _dropout_tensor_big_diff_pad():
+        dropout(stack)
+    return _dropout_tensor_big_diff_pad
+
+def dropout_tensor_big_diff_iter():
+    inputs = get_input_big_diff()
+
+    def _dropout_tensor_big_diff_iter():
+        for t in inputs:
+            dropout(t.unsqueeze(0)).squeeze(0)
+    return _dropout_tensor_big_diff_iter
+
+def dropout_nt_big_diff():
+    inputs = get_input_big_diff()
+    nt = nestedtensor.nested_tensor(inputs)
+
+    def _dropout_nt_big_diff():
+        dropout(nt)
+
+    return _dropout_nt_big_diff
 
 #
 # interpolate
 #
+interpolate = torch.nn.functional.interpolate
 def interpolate_tensor_tensors_same_size():
     inputs = [torch.randn(C, H, W) for _ in range(N)]
     a = torch.stack(inputs)
 
     def _interpolate_tensor():
-        torch.nn.functional.interpolate(a, inputs[0].unsqueeze(0).shape[-2])
+        interpolate(a, inputs[0].unsqueeze(0).shape[-2])
     return _interpolate_tensor
 
 def interpolate_nt_tensors_same_size():
     inputs = [torch.randn(C, H, W) for _ in range(N)]
     nt = nestedtensor.nested_tensor(inputs)
     def _interpolate_nt():
-        torch.nn.functional.interpolate(nt)
-    
+        interpolate(nt)
+
     return _interpolate_nt
 
+def interpolate_tensor_small_diff_pad():
+    inputs = get_input_small_diff(pad=True)
+    stack = torch.stack(inputs)
+    
+    def _interpolate_tensor_small_diff_pad():
+        interpolate(stack, inputs[0].unsqueeze(0).shape[-2])
+    return _interpolate_tensor_small_diff_pad
+
+def interpolate_tensor_small_diff_iter():
+    inputs = get_input_small_diff()
+    
+    def _interpolate_tensor_small_diff_iter():
+        for t in inputs:
+            interpolate(t, t.unsqueeze(0).shape[-2])
+    return _interpolate_tensor_small_diff_iter
+
+def interpolate_nt_small_diff():
+    inputs = get_input_small_diff()
+    nt = nestedtensor.nested_tensor(inputs)
+
+    def _interpolate_nt_small_diff():
+        interpolate(nt)
+
+    return _interpolate_nt_small_diff
+
+def interpolate_tensor_big_diff_pad():
+    inputs = get_input_big_diff(pad=True)
+    stack = torch.stack(inputs)
+
+    def _interpolate_tensor_big_diff_pad():
+        interpolate(stack, inputs[0].unsqueeze(0).shape[-2])
+    return _interpolate_tensor_big_diff_pad
+
+def interpolate_tensor_big_diff_iter():
+    inputs = get_input_big_diff()
+
+    def _interpolate_tensor_big_diff_iter():
+        for t in inputs:
+            interpolate(t, t.unsqueeze(0).shape[-2])
+    return _interpolate_tensor_big_diff_iter
+
+def interpolate_nt_big_diff():
+    inputs = get_input_big_diff()
+    nt = nestedtensor.nested_tensor(inputs)
+
+    def _interpolate_nt_big_diff():
+        interpolate(nt)
+
+    return _interpolate_nt_big_diff
 
 if __name__ == "__main__":
-    print(utils.benchmark_fn(relu_tensor_tensors_same_size(), warmup=2.0))
-    print(utils.benchmark_fn(relu_nt_tensors_same_size(), warmup=2.0))
-    print(utils.benchmark_fn(conv2d_tensor_tensors_same_size(), warmup=2.0))
-    print(utils.benchmark_fn(conv2d_nt_tensors_same_size(), warmup=2.0))
-    print(utils.benchmark_fn(batch_norm_tensor_tensors_same_size(), warmup=2.0))
-    print(utils.benchmark_fn(batch_norm_nt_tensors_same_size(), warmup=2.0))
-    print(utils.benchmark_fn(max_pool2d_tensor_tensors_same_size(), warmup=2.0))
-    print(utils.benchmark_fn(max_pool2d_nt_tensors_same_size(), warmup=2.0))
-    print(utils.benchmark_fn(cross_entropy_tensor_tensors_same_size(), warmup=2.0))
-    print(utils.benchmark_fn(cross_entropy_nt_tensors_same_size(), warmup=2.0))
-    print(utils.benchmark_fn(dropout_tensor_tensors_same_size(), warmup=2.0))
-    print(utils.benchmark_fn(dropout_nt_tensors_same_size(), warmup=2.0))
-    print(utils.benchmark_fn(interpolate_tensor_tensors_same_size(), warmup=2.0))
-    print(utils.benchmark_fn(interpolate_nt_tensors_same_size(), warmup=2.0))
+    # relu
+    print(utils.benchmark_fn(relu_tensor_tensors_same_size(), warmup=WARM))
+    print(utils.benchmark_fn(relu_nt_tensors_same_size(), warmup=WARM))
+    print(utils.benchmark_fn(relu_tensor_small_diff_pad(), warmup=WARM))
+    print(utils.benchmark_fn(relu_tensor_small_diff_iter(), warmup=WARM))
+    print(utils.benchmark_fn(relu_nt_small_diff(), warmup=WARM))
+    print(utils.benchmark_fn(relu_tensor_big_diff_pad(), warmup=WARM))
+    print(utils.benchmark_fn(relu_tensor_big_diff_iter(), warmup=WARM))
+    print(utils.benchmark_fn(relu_nt_big_diff(), warmup=WARM))
 
+    # conv2d
+    print(utils.benchmark_fn(conv2d_tensor_tensors_same_size(), warmup=WARM))
+    print(utils.benchmark_fn(conv2d_nt_tensors_same_size(), warmup=WARM))
+    print(utils.benchmark_fn(conv2d_tensor_small_diff_pad(), warmup=WARM))
+    print(utils.benchmark_fn(conv2d_tensor_small_diff_iter(), warmup=WARM))
+    print(utils.benchmark_fn(conv2d_nt_small_diff(), warmup=WARM))
+    print(utils.benchmark_fn(conv2d_tensor_big_diff_pad(), warmup=WARM))
+    print(utils.benchmark_fn(conv2d_tensor_big_diff_iter(), warmup=WARM))
+    print(utils.benchmark_fn(conv2d_nt_big_diff(), warmup=WARM))
+
+    # batch_norm
+    print(utils.benchmark_fn(batch_norm_tensor_tensors_same_size(), warmup=WARM))
+    print(utils.benchmark_fn(batch_norm_nt_tensors_same_size(), warmup=WARM))
+    print(utils.benchmark_fn(batch_norm_tensor_small_diff_pad(), warmup=WARM))
+    print(utils.benchmark_fn(batch_norm_tensor_small_diff_iter(), warmup=WARM))
+    print(utils.benchmark_fn(batch_norm_nt_small_diff(), warmup=WARM))  
+    print(utils.benchmark_fn(batch_norm_tensor_big_diff_pad(), warmup=WARM))
+    print(utils.benchmark_fn(batch_norm_tensor_big_diff_iter(), warmup=WARM))
+    print(utils.benchmark_fn(batch_norm_nt_big_diff(), warmup=WARM))
+
+    # max_pool2d
+    print(utils.benchmark_fn(max_pool2d_tensor_tensors_same_size(), warmup=WARM))
+    print(utils.benchmark_fn(max_pool2d_nt_tensors_same_size(), warmup=WARM))
+    print(utils.benchmark_fn(max_pool2d_tensor_small_diff_pad(), warmup=WARM))
+    print(utils.benchmark_fn(max_pool2d_tensor_small_diff_iter(), warmup=WARM))
+    print(utils.benchmark_fn(max_pool2d_nt_small_diff(), warmup=WARM))
+    print(utils.benchmark_fn(max_pool2d_tensor_big_diff_pad(), warmup=WARM))
+    print(utils.benchmark_fn(max_pool2d_tensor_big_diff_iter(), warmup=WARM))
+    print(utils.benchmark_fn(max_pool2d_nt_big_diff(), warmup=WARM))
+
+    # cross_entropy
+    print(utils.benchmark_fn(cross_entropy_tensor_tensors_same_size(), warmup=WARM))
+    print(utils.benchmark_fn(cross_entropy_nt_tensors_same_size(), warmup=WARM))
+    print(utils.benchmark_fn(cross_entropy_tensor_small_diff_pad(), warmup=WARM))
+    print(utils.benchmark_fn(cross_entropy_tensor_small_diff_iter(), warmup=WARM))
+    print(utils.benchmark_fn(cross_entropy_nt_small_diff(), warmup=WARM))
+    print(utils.benchmark_fn(cross_entropy_tensor_big_diff_pad(), warmup=WARM))
+    print(utils.benchmark_fn(cross_entropy_tensor_big_diff_iter(), warmup=WARM))
+    print(utils.benchmark_fn(cross_entropy_nt_big_diff(), warmup=WARM))
+
+    # dropout
+    print(utils.benchmark_fn(dropout_tensor_tensors_same_size(), warmup=WARM))
+    print(utils.benchmark_fn(dropout_nt_tensors_same_size(), warmup=WARM))
+    print(utils.benchmark_fn(dropout_tensor_small_diff_pad(), warmup=WARM))
+    print(utils.benchmark_fn(dropout_tensor_small_diff_iter(), warmup=WARM))
+    print(utils.benchmark_fn(dropout_nt_small_diff(), warmup=WARM))
+    print(utils.benchmark_fn(dropout_tensor_big_diff_pad(), warmup=WARM))
+    print(utils.benchmark_fn(dropout_tensor_big_diff_iter(), warmup=WARM))
+    print(utils.benchmark_fn(dropout_nt_big_diff(), warmup=WARM))
+
+    # interpolate
+    print(utils.benchmark_fn(interpolate_tensor_tensors_same_size(), warmup=WARM))
+    print(utils.benchmark_fn(interpolate_nt_tensors_same_size(), warmup=WARM))
+    print(utils.benchmark_fn(interpolate_tensor_small_diff_pad(), warmup=WARM))
+    print(utils.benchmark_fn(interpolate_tensor_small_diff_iter(), warmup=WARM))
+    print(utils.benchmark_fn(interpolate_nt_small_diff(), warmup=WARM))
+    print(utils.benchmark_fn(interpolate_tensor_big_diff_pad(), warmup=WARM))
+    print(utils.benchmark_fn(interpolate_tensor_big_diff_iter(), warmup=WARM))
+    print(utils.benchmark_fn(interpolate_nt_big_diff(), warmup=WARM))

--- a/benchmarks/segmentation_layers.py
+++ b/benchmarks/segmentation_layers.py
@@ -2,702 +2,328 @@ import torch
 import nestedtensor
 import utils
 import torch.nn.functional as F
+import sys 
+import random
 
-N = 6
-C = 30
-H = 500
-W = 600
+class SegLayersBenchMark(object):
+    def __init__(self, args):
+        assert len(args) == 6
+        print("Called with args: ")
+        
+        self.N = int(args[0])
+        print("N = ", self.N)
 
-N1 = 3
-C1 = 30
-H1 = 100
-W1 = 200
+        self.C = int(args[1])
+        print("C = ", self.C)
 
-N2 = 3
-C2 = 30
-H2 = 400
-W2 = 800
+        self.H = int(args[2])
+        print("H = ", self.H)
 
-N3 = 3
-C3 = 30
-H3 = 1000
-W3 = 2000
+        self.W = int(args[3])
+        print("W = ", self.W)
+        
+        self.delta = float(args[4])
+        print("delta = ", self.W)
 
-WARM = 2.0
+        self.warmup = float(args[5])
+        print("warmup = ", self.W)
+        
+        self.conv2d = torch.nn.Conv2d(self.C, 3, kernel_size= (1, 1), bias=False)
+        self.batch_norm = torch.nn.BatchNorm2d(self.C, 1e-05, 0.1)
+        self.batch_norm.eval()
+        self.max_pool2d = torch.nn.MaxPool2d(kernel_size=(2, 2), stride=(2, 2), padding=(0, 0), dilation=(1, 1))
 
-def get_max_size(obj, res=None):
-    if res is None:
-        res = [1]
-
-    if isinstance(obj, list) or isinstance(obj, tuple):
-        for o in obj:
-            res = get_max_size(o, res)
-
-    if isinstance(obj, nestedtensor.nested.nested.NestedTensor):
-        tres = get_max_size(obj.unbind())
-        while len(tres) > len(res):
-                res.append(0)
-
-        res = [max(i, j) for (i, j) in zip(res, tres)]
-
-    if isinstance(obj, torch.Tensor):
-        # scalar
-        if obj.dim() == 0 and obj.numel() == 1:
+    def get_max_size(self, obj, res=None):
+        if res is None:
             res = [1]
-        else:
-            while len(obj.size()) > len(res):
-                res.append(0)
-
-            res = [max(i, j) for (i, j) in zip(res, obj.size())]
-
-    return res
-
-def pad_tensor_to_shape(t, goal_shape):
-    padd = ()
-    tup = tuple(t.size())
-    assert(t.dim() == len(goal_shape))
-    for i in range(len(tup)):
-        padd = (0, goal_shape[i] - tup[i]) + padd
-    new_tensor = F.pad(t, padd)
-    new_tensor = new_tensor.reshape(goal_shape)
-    return new_tensor
-
-def pad_tensors_to_max_shape(inputs):
-    max_shape = get_max_size(inputs)
-    padded_inputs = [pad_tensor_to_shape(t, max_shape) for t in inputs]
-    return padded_inputs
-
-def get_input_small_diff(pad=False):
-    inputs = [torch.randn(C1, H1, W1) for _ in range(N1)]
-    inputs2 = [torch.randn(C2, H2, W2) for _ in range(N2)]
-    inputs = inputs + inputs2
-
-    if pad:
-        return pad_tensors_to_max_shape(inputs)
-    return inputs
 
-def get_input_big_diff(pad=False):
-    inputs = [torch.randn(C1, H1, W1) for _ in range(N1)]
-    inputs2 = [torch.randn(C3, H3, W3) for _ in range(N3)]
-    inputs = inputs + inputs2
+        if isinstance(obj, list) or isinstance(obj, tuple):
+            for o in obj:
+                res = self.get_max_size(o, res)
+
+        if isinstance(obj, nestedtensor.nested.nested.NestedTensor):
+            tres = self.get_max_size(obj.unbind())
+            while len(tres) > len(res):
+                    res.append(0)
+
+            res = [max(i, j) for (i, j) in zip(res, tres)]
+
+        if isinstance(obj, torch.Tensor):
+            # scalar
+            if obj.dim() == 0 and obj.numel() == 1:
+                res = [1]
+            else:
+                while len(obj.size()) > len(res):
+                    res.append(0)
+
+                res = [max(i, j) for (i, j) in zip(res, obj.size())]
+
+        return res
+
+    def pad_tensor_to_shape(self, t, goal_shape):
+        padd = ()
+        tup = tuple(t.size())
+        assert(t.dim() == len(goal_shape))
+        for i in range(len(tup)):
+            padd = (0, goal_shape[i] - tup[i]) + padd
+        new_tensor = F.pad(t, padd)
+        new_tensor = new_tensor.reshape(goal_shape)
+        return new_tensor
+
+    def pad_tensors_to_max_shape(self, inputs):
+        max_shape = self.get_max_size(inputs)
+        padded_inputs = [self.pad_tensor_to_shape(t, max_shape) for t in inputs]
+        return padded_inputs
+
+    def get_input(self, return_targets=False, pad=False):
+        inputs = []
+        targets = []
+        for i in range(self.N):
+            h_change = random.randint(self.delta * 10 * (-self.H), self.delta * 10 * self.H) / 10
+            w_change = random.randint(self.delta * 10 * (-self.W), self.delta * 10 * self.W) / 10
+            inputs.append(torch.randn(self.C, self.H, self.W))
+            targets.append(torch.randint(1, (self.H, self.W), dtype=torch.int64))
+
+        if pad:
+            inputs = self.pad_tensors_to_max_shape(inputs)
+
+        if return_targets:
+            return inputs, targets
+
+        return inputs
+
+    #
+    # relu
+    #
+    def relu_tensor_iter(self):
+        inputs = self.get_input()
+
+        def _relu_tensor_iter():
+            for t in inputs:
+                torch.nn.functional.relu(t)
+        return _relu_tensor_iter
+
+    def relu_tensor_pad(self):
+        inputs = self.get_input(pad=True)
+        stack = torch.stack(inputs)
+
+        def _relu_tensor_pad():
+            torch.nn.functional.relu(stack)
+
+        return _relu_tensor_pad
+
+    def relu_nt(self):
+        inputs = self.get_input()
+        nt = nestedtensor.nested_tensor(inputs)
+        def _relu_nt():
+            torch.nn.functional.relu(nt)
+        
+        return _relu_nt
+
+    #
+    # conv2d
+    #
+    def conv2d_tensor_iter(self):
+        inputs = self.get_input()
+
+        def _conv2d_tensor_iter():
+            for t in inputs:
+                self.conv2d(t.unsqueeze(0)).squeeze(0)
+        return _conv2d_tensor_iter
+
+    def conv2d_tensor_pad(self):
+        inputs = self.get_input(pad=True)
+        stack = torch.stack(inputs)
+
+        def _conv2d_tensor_pad():
+            self.conv2d(stack)
 
-    if pad: 
-        return pad_tensors_to_max_shape(inputs)
-    return inputs
+        return _conv2d_tensor_pad
 
-def get_targets_small_diff(pad = False):
-    targets = [torch.randint(1, (H1, W1), dtype=torch.int64) for _ in range(N1)]
-    targets2 = [torch.randint(1, (H2, W2), dtype=torch.int64) for _ in range(N2)]
-    trg = targets + targets2
-
-    if pad: 
-        return pad_tensors_to_max_shape(trg)
-
-    return trg
-
-def get_targets_big_diff(pad = False):
-    targets = [torch.randint(1, (H1, W1), dtype=torch.int64) for _ in range(N1)]
-    targets2 = [torch.randint(1, (H3, W3), dtype=torch.int64) for _ in range(N3)]
-    trg = targets + targets2
-
-    if pad: 
-        return pad_tensors_to_max_shape(trg)
-
-    return trg
-
-#
-# relu
-#
-def relu_tensor_tensors_same_size():
-    inputs = [torch.randn(C, H, W) for _ in range(N)]
-    a = torch.stack(inputs)
-
-    def _relu_tensor():
-        torch.nn.functional.relu(a)
-    return _relu_tensor
-
-def relu_nt_tensors_same_size():
-    inputs = [torch.randn(C, H, W) for _ in range(N)]
-    nt = nestedtensor.nested_tensor(inputs)
-    def _relu_nt():
-        torch.nn.functional.relu(nt)
-    
-    return _relu_nt
-
-def relu_tensor_small_diff_pad():
-    inputs = get_input_small_diff(pad=True)
-    stack = torch.stack(inputs)
-
-    def _relu_tensor_small_diff_pad():
-        torch.nn.functional.relu(stack)
-    return _relu_tensor_small_diff_pad
-
-def relu_tensor_small_diff_iter():
-    inputs = get_input_small_diff()
-
-    def _relu_tensor_small_diff_iter():
-        for t in inputs:
-            torch.nn.functional.relu(t)
-    return _relu_tensor_small_diff_iter
-
-def relu_nt_small_diff():
-    inputs = get_input_small_diff()
-    nt = nestedtensor.nested_tensor(inputs)
-
-    def _relu_nt_small_diff():
-        torch.nn.functional.relu(nt)
+    def conv2d_nt(self):
+        inputs = self.get_input()
+        nt = nestedtensor.nested_tensor(inputs)
+        def _conv2d_nt():
+            self.conv2d(nt)
+
+        return _conv2d_nt
 
-    return _relu_nt_small_diff
+    #
+    # batch_norm
+    #
+    def batch_norm_tensor_iter(self):
+        inputs = self.get_input()
 
-def relu_tensor_big_diff_pad():
-    inputs = get_input_big_diff(pad=True)
-    stack = torch.stack(inputs)
+        def _batch_norm_tensor_iter():
+            for t in inputs:
+                self.batch_norm(t.unsqueeze(0)).squeeze(0)
+        return _batch_norm_tensor_iter
 
-    def _relu_tensor_big_diff_pad():
-        torch.nn.functional.relu(stack)
-    return _relu_tensor_big_diff_pad
+    def batch_norm_tensor_pad(self):
+        inputs = self.get_input(pad=True)
+        stack = torch.stack(inputs)
 
-def relu_tensor_big_diff_iter():
-    inputs = get_input_big_diff()
+        def _batch_norm_tensor_pad():
+            self.batch_norm(stack)
 
-    def _relu_tensor_big_diff_iter():
-        for t in inputs:
-            torch.nn.functional.relu(t)
-    return _relu_tensor_big_diff_iter
+        return _batch_norm_tensor_pad
 
-def relu_nt_big_diff():
-    inputs = get_input_big_diff()
-    nt = nestedtensor.nested_tensor(inputs)
+    def batch_norm_nt(self):
+        inputs = self.get_input()
+        nt = nestedtensor.nested_tensor(inputs)
+        def _batch_norm_nt():
+            self.batch_norm(nt)
 
-    def _relu_nt_big_diff():
-        torch.nn.functional.relu(nt)
+        return _batch_norm_nt
 
-    return _relu_nt_big_diff
+    #
+    # max_pool2d
+    #
+    def max_pool2d_tensor_iter(self):
+        inputs = self.get_input()
 
+        def _max_pool2d_tensor_iter():
+            for t in inputs:
+                self.max_pool2d(t.unsqueeze(0)).squeeze(0)
+        return _max_pool2d_tensor_iter
 
-#
-# conv2d
-#
-conv2d = torch.nn.Conv2d(30, 33, kernel_size= (3, 5), bias=False)
+    def max_pool2d_tensor_pad(self):
+        inputs = self.get_input(pad=True)
+        stack = torch.stack(inputs)
 
-def conv2d_tensor_tensors_same_size():
-    inputs = [torch.randn(C, H, W) for _ in range(N)]
-    a = torch.stack(inputs)
+        def _max_pool2d_tensor_pad():
+            self.max_pool2d(stack)
 
-    def _conv2d_tensor_tensors_same_size():
-        conv2d(a)
-    return _conv2d_tensor_tensors_same_size
+        return _max_pool2d_tensor_pad
 
-def conv2d_nt_tensors_same_size():
-    inputs = [torch.randn(C, H, W) for _ in range(N)]
-    nt = nestedtensor.nested_tensor(inputs)
-    def _conv2d_nt_tensors_same_size():
-        conv2d(nt)
-
-    return _conv2d_nt_tensors_same_size
+    def max_pool2d_nt(self):
+        inputs = self.get_input()
+        nt = nestedtensor.nested_tensor(inputs)
+        def _max_pool2d_nt():
+            self.max_pool2d(nt)
 
-def conv2d_tensor_small_diff_pad():
-    inputs = get_input_small_diff(pad=True)
-    stack = torch.stack(inputs)
-    
-    def _conv2d_tensor_small_diff_pad():
-        conv2d(stack)
-    return _conv2d_tensor_small_diff_pad
+        return _max_pool2d_nt
 
-def conv2d_tensor_small_diff_iter():
-    inputs = get_input_small_diff()
-    
-    def _conv2d_tensor_small_diff_iter():
-        for t in inputs:
-            conv2d(t.unsqueeze(0)).squeeze(0)
-    return _conv2d_tensor_small_diff_iter
+    #
+    # cross_entropy
+    #
+    def cross_entropy_tensor_iter(self):
+        inputs, targets = self.get_input(return_targets=True)
 
-def conv2d_nt_small_diff():
-    inputs = get_input_small_diff()
-    nt = nestedtensor.nested_tensor(inputs)
+        def _cross_entropy_tensor_iter():
+            for a, b in zip(inputs, targets):
+                torch.nn.functional.cross_entropy(a.unsqueeze(0), b.unsqueeze(0)).squeeze(0)
+        return _cross_entropy_tensor_iter
 
-    def _conv2d_nt_small_diff():
-        conv2d(nt)
-
-    return _conv2d_nt_small_diff
-
-def conv2d_tensor_big_diff_pad():
-    inputs = get_input_big_diff(pad=True)
-    stack = torch.stack(inputs)
-
-    def _conv2d_tensor_big_diff_pad():
-        conv2d(stack)
-    return _conv2d_tensor_big_diff_pad
-
-def conv2d_tensor_big_diff_iter():
-    inputs = get_input_big_diff()
-
-    def _conv2d_tensor_big_diff_iter():
-        for t in inputs:
-            conv2d(t.unsqueeze(0)).squeeze(0)
-    return _conv2d_tensor_big_diff_iter
-
-def conv2d_nt_big_diff():
-    inputs = get_input_big_diff()
-    nt = nestedtensor.nested_tensor(inputs)
-
-    def _conv2d_nt_big_diff():
-        conv2d(nt)
-
-    return _conv2d_nt_big_diff
-
-
-#
-# batch_norm
-#
-batch_norm = torch.nn.BatchNorm2d(30, 1e-05, 0.1)
-
-def batch_norm_tensor_tensors_same_size():
-    inputs = [torch.randn(C, H, W) for _ in range(N)]
-    a = torch.stack(inputs)
-    batch_norm.eval()
-
-    def _batch_norm_tensor():
-        batch_norm(a)
-    return _batch_norm_tensor
-
-def batch_norm_nt_tensors_same_size():
-    inputs = [torch.randn(C, H, W) for _ in range(N)]
-    nt = nestedtensor.nested_tensor(inputs)
-    batch_norm.eval()
-
-    def _batch_norm_nt():
-        batch_norm(nt)
-    
-    return _batch_norm_nt
-
-def batch_norm_tensor_small_diff_pad():
-    inputs = get_input_small_diff(pad=True)
-    stack = torch.stack(inputs)
-    batch_norm.eval()
-
-    def _batch_norm_tensor_small_diff_pad():
-        batch_norm(stack)
-    return _batch_norm_tensor_small_diff_pad
-
-def batch_norm_tensor_small_diff_iter():
-    inputs = get_input_small_diff()
-    batch_norm.eval()
-
-    def _batch_norm_tensor_small_diff_iter():
-        for t in inputs:
-            batch_norm(t.unsqueeze(0)).squeeze(0)
-    return _batch_norm_tensor_small_diff_iter
-
-def batch_norm_nt_small_diff():
-    inputs = get_input_small_diff()
-    nt = nestedtensor.nested_tensor(inputs)
-    batch_norm.eval()
-
-    def _batch_norm_nt_small_diff():
-        batch_norm(nt)
-
-    return _batch_norm_nt_small_diff
-
-def batch_norm_tensor_big_diff_pad():
-    inputs = get_input_big_diff(pad=True)
-    stack = torch.stack(inputs)
-    batch_norm.eval()
-
-    def _batch_norm_tensor_big_diff_pad():
-        batch_norm(stack)
-    return _batch_norm_tensor_big_diff_pad
-
-def batch_norm_tensor_big_diff_iter():
-    inputs = get_input_big_diff()
-    batch_norm.eval()
-
-    def _batch_norm_tensor_big_diff_iter():
-        for t in inputs:
-            batch_norm(t.unsqueeze(0)).squeeze(0)
-    return _batch_norm_tensor_big_diff_iter
-
-def batch_norm_nt_big_diff():
-    inputs = get_input_big_diff()
-    nt = nestedtensor.nested_tensor(inputs)
-    batch_norm.eval()
-
-    def _batch_norm_nt_big_diff():
-        batch_norm(nt)
-
-    return _batch_norm_nt_big_diff
-
-#
-# max_pool2d
-#
-max_pool2d = torch.nn.MaxPool2d(kernel_size=(2, 2), stride=(2, 2), padding=(0, 0), dilation=(1, 1))
-
-def max_pool2d_tensor_tensors_same_size():
-    inputs = [torch.randn(C, H, W) for _ in range(N)]
-    a = torch.stack(inputs)
-
-    def _max_pool2d_tensor():
-        max_pool2d(a)
-    return _max_pool2d_tensor
-
-def max_pool2d_nt_tensors_same_size():
-    inputs = [torch.randn(C, H, W) for _ in range(N)]
-    nt = nestedtensor.nested_tensor(inputs)
-
-    def _max_pool2d_nt():
-        max_pool2d(nt)
-
-    return _max_pool2d_nt
-
-def max_pool2d_tensor_small_diff_pad():
-    inputs = get_input_small_diff(pad=True)
-    stack = torch.stack(inputs)
-    
-    def _max_pool2d_tensor_small_diff_pad():
-        max_pool2d(stack)
-    return _max_pool2d_tensor_small_diff_pad
-
-def max_pool2d_tensor_small_diff_iter():
-    inputs = get_input_small_diff()
-
-    def _max_pool2d_tensor_small_diff_iter():
-        for t in inputs:
-            max_pool2d(t)
-    return _max_pool2d_tensor_small_diff_iter
-
-def max_pool2d_nt_small_diff():
-    inputs = get_input_small_diff()
-    nt = nestedtensor.nested_tensor(inputs)
-
-    def _max_pool2d_nt_small_diff():
-        max_pool2d(nt)
-
-    return _max_pool2d_nt_small_diff
-
-def max_pool2d_tensor_big_diff_pad():
-    inputs = get_input_big_diff(pad=True)
-    stack = torch.stack(inputs)
-
-    def _max_pool2d_tensor_big_diff_pad():
-        max_pool2d(stack)
-    return _max_pool2d_tensor_big_diff_pad
-
-def max_pool2d_tensor_big_diff_iter():
-    inputs = get_input_big_diff()
-
-    def _max_pool2d_tensor_big_diff_iter():
-        for t in inputs:
-            max_pool2d(t)
-    return _max_pool2d_tensor_big_diff_iter
-
-def max_pool2d_nt_big_diff():
-    inputs = get_input_big_diff()
-    nt = nestedtensor.nested_tensor(inputs)
-
-    def _max_pool2d_nt_big_diff():
-        max_pool2d(nt)
-
-    return _max_pool2d_nt_big_diff
-
-#
-# cross_entropy
-#
-cross_entropy = torch.nn.functional.cross_entropy
-def cross_entropy_tensor_tensors_same_size():
-    inputs = [torch.randn(C, H, W) for _ in range(N)]
-    targets = [torch.randint(1, (H, W), dtype=torch.int64) for _ in range(N)]
-    
-    a = torch.stack(inputs)
-    b = torch.stack(targets)
-    
-
-    def _cross_entropy_tensor():
-        cross_entropy(a, b)
-    return _cross_entropy_tensor
-
-def cross_entropy_nt_tensors_same_size():
-    inputs = [torch.randn(C, H, W) for _ in range(N)]
-    targets = [torch.randint(1, (H, W), dtype=torch.int64) for _ in range(N)]
-
-    a = nestedtensor.nested_tensor(inputs)
-    b = nestedtensor.nested_tensor(targets)
-
-    def _cross_entropy_nt():
-        cross_entropy(a, b)
-    return _cross_entropy_nt
-
-def cross_entropy_tensor_small_diff_pad():
-    inputs = get_input_small_diff(pad=True)
-    targets = get_targets_small_diff(pad=True)
-
-    a = torch.stack(inputs)
-    b = torch.stack(targets)
-
-    def _cross_entropy_tensor_small_diff_pad():
-        cross_entropy(a, b)
-    return _cross_entropy_tensor_small_diff_pad
-
-def cross_entropy_tensor_small_diff_iter():
-    inputs = get_input_small_diff()
-    targets = get_targets_small_diff()
-
-    def _cross_entropy_tensor_small_diff_iter():
-        for a, b in zip(inputs, targets):
-            cross_entropy(a.unsqueeze(0), b.unsqueeze(0)).squeeze(0)
-    return _cross_entropy_tensor_small_diff_iter
-
-def cross_entropy_nt_small_diff():
-    inputs = get_input_small_diff()
-    targets = get_targets_small_diff()
-
-    nt_input = nestedtensor.nested_tensor(inputs)
-    nt_target = nestedtensor.nested_tensor(targets)
-
-    def _cross_entropy_nt_small_diff():
-        cross_entropy(nt_input, nt_target)
-
-    return _cross_entropy_nt_small_diff
-
-def cross_entropy_tensor_big_diff_pad():
-    inputs = get_input_big_diff(pad=True)
-    targets = get_targets_big_diff(pad=True)
-
-    a = torch.stack(inputs)
-    b = torch.stack(targets)
-
-    def _cross_entropy_tensor_big_diff_pad():
-        cross_entropy(a, b)
-    return _cross_entropy_tensor_big_diff_pad
-
-def cross_entropy_tensor_big_diff_iter():
-    inputs = get_input_big_diff()
-    targets = get_targets_big_diff()
-
-    def _cross_entropy_tensor_big_diff_iter():
-        for a, b in zip(inputs, targets):
-            cross_entropy(a.unsqueeze(0), b.unsqueeze(0)).squeeze(0)
-    return _cross_entropy_tensor_big_diff_iter
-
-def cross_entropy_nt_big_diff():
-    inputs = get_input_big_diff()
-    targets = get_targets_big_diff()
-    
-    nt_input = nestedtensor.nested_tensor(inputs)
-    nt_target = nestedtensor.nested_tensor(targets)
-
-    def _cross_entropy_nt_big_diff():
-        cross_entropy(nt_input, nt_target)
-
-    return _cross_entropy_nt_big_diff
-
-#
-# dropout
-#
-dropout = torch.nn.functional.dropout
-
-def dropout_tensor_tensors_same_size():
-    inputs = [torch.randn(C, H, W) for _ in range(N)]
-    a = torch.stack(inputs)
-
-    def _dropout_tensor():
-        dropout(a)
-    return _dropout_tensor
-
-def dropout_nt_tensors_same_size():
-    inputs = [torch.randn(C, H, W) for _ in range(N)]
-    nt = nestedtensor.nested_tensor(inputs)
-    def _dropout_nt():
-        dropout(nt)
-
-    return _dropout_nt
-
-def dropout_tensor_small_diff_pad():
-    inputs = get_input_small_diff(pad=True)
-    stack = torch.stack(inputs)
-    
-    def _dropout_tensor_small_diff_pad():
-        dropout(stack)
-    return _dropout_tensor_small_diff_pad
-
-def dropout_tensor_small_diff_iter():
-    inputs = get_input_small_diff()
-    
-    def _dropout_tensor_small_diff_iter():
-        for t in inputs:
-            dropout(t.unsqueeze(0)).squeeze(0)
-    return _dropout_tensor_small_diff_iter
-
-def dropout_nt_small_diff():
-    inputs = get_input_small_diff()
-    nt = nestedtensor.nested_tensor(inputs)
-
-    def _dropout_nt_small_diff():
-        dropout(nt)
-
-    return _dropout_nt_small_diff
-
-def dropout_tensor_big_diff_pad():
-    inputs = get_input_big_diff(pad=True)
-    stack = torch.stack(inputs)
-
-    def _dropout_tensor_big_diff_pad():
-        dropout(stack)
-    return _dropout_tensor_big_diff_pad
-
-def dropout_tensor_big_diff_iter():
-    inputs = get_input_big_diff()
-
-    def _dropout_tensor_big_diff_iter():
-        for t in inputs:
-            dropout(t.unsqueeze(0)).squeeze(0)
-    return _dropout_tensor_big_diff_iter
-
-def dropout_nt_big_diff():
-    inputs = get_input_big_diff()
-    nt = nestedtensor.nested_tensor(inputs)
-
-    def _dropout_nt_big_diff():
-        dropout(nt)
-
-    return _dropout_nt_big_diff
-
-#
-# interpolate
-#
-interpolate = torch.nn.functional.interpolate
-def interpolate_tensor_tensors_same_size():
-    inputs = [torch.randn(C, H, W) for _ in range(N)]
-    a = torch.stack(inputs)
-
-    def _interpolate_tensor():
-        interpolate(a, inputs[0].unsqueeze(0).shape[-2])
-    return _interpolate_tensor
-
-def interpolate_nt_tensors_same_size():
-    inputs = [torch.randn(C, H, W) for _ in range(N)]
-    nt = nestedtensor.nested_tensor(inputs)
-    def _interpolate_nt():
-        interpolate(nt)
-
-    return _interpolate_nt
-
-def interpolate_tensor_small_diff_pad():
-    inputs = get_input_small_diff(pad=True)
-    stack = torch.stack(inputs)
-    
-    def _interpolate_tensor_small_diff_pad():
-        interpolate(stack, inputs[0].unsqueeze(0).shape[-2])
-    return _interpolate_tensor_small_diff_pad
-
-def interpolate_tensor_small_diff_iter():
-    inputs = get_input_small_diff()
-    
-    def _interpolate_tensor_small_diff_iter():
-        for t in inputs:
-            interpolate(t, t.unsqueeze(0).shape[-2])
-    return _interpolate_tensor_small_diff_iter
-
-def interpolate_nt_small_diff():
-    inputs = get_input_small_diff()
-    nt = nestedtensor.nested_tensor(inputs)
-
-    def _interpolate_nt_small_diff():
-        interpolate(nt)
-
-    return _interpolate_nt_small_diff
-
-def interpolate_tensor_big_diff_pad():
-    inputs = get_input_big_diff(pad=True)
-    stack = torch.stack(inputs)
-
-    def _interpolate_tensor_big_diff_pad():
-        interpolate(stack, inputs[0].unsqueeze(0).shape[-2])
-    return _interpolate_tensor_big_diff_pad
-
-def interpolate_tensor_big_diff_iter():
-    inputs = get_input_big_diff()
-
-    def _interpolate_tensor_big_diff_iter():
-        for t in inputs:
-            interpolate(t, t.unsqueeze(0).shape[-2])
-    return _interpolate_tensor_big_diff_iter
-
-def interpolate_nt_big_diff():
-    inputs = get_input_big_diff()
-    nt = nestedtensor.nested_tensor(inputs)
-
-    def _interpolate_nt_big_diff():
-        interpolate(nt)
-
-    return _interpolate_nt_big_diff
+    def cross_entropy_tensor_pad(self):
+        inputs, targets = self.get_input(return_targets=True, pad=True)
+        i_stack = torch.stack(inputs)
+        t_stack = torch.stack(targets)
+
+        def _cross_entropy_tensor_pad():
+            torch.nn.functional.cross_entropy(i_stack, t_stack)
+
+        return _cross_entropy_tensor_pad
+
+    def cross_entropy_nt(self):
+        inputs, targets = self.get_input(return_targets=True, pad=True)
+        i_nt = nestedtensor.nested_tensor(inputs)
+        t_nt = nestedtensor.nested_tensor(targets)
+        def _cross_entropy_nt():
+            torch.nn.functional.cross_entropy(i_nt, t_nt)
+
+        return _cross_entropy_nt
+
+
+    #
+    # dropout
+    #
+    def dropout_tensor_iter(self):
+        inputs = self.get_input()
+
+        def _dropout_tensor_iter():
+            for t in inputs:
+                torch.nn.functional.dropout(t.unsqueeze(0)).squeeze(0)
+        return _dropout_tensor_iter
+
+    def dropout_tensor_pad(self):
+        inputs = self.get_input(pad=True)
+        stack = torch.stack(inputs)
+
+        def _dropout_tensor_pad():
+            torch.nn.functional.dropout(stack)
+
+        return _dropout_tensor_pad
+
+    def dropout_nt(self):
+        inputs = self.get_input()
+        nt = nestedtensor.nested_tensor(inputs)
+        def _dropout_nt():
+            torch.nn.functional.dropout(nt)
+
+        return _dropout_nt
+        inputs = get_input_big_diff()
+        nt = nestedtensor.nested_tensor(inputs)
+
+        def _dropout_nt_big_diff():
+            dropout(nt)
+
+        return _dropout_nt_big_diff
+
+    #
+    # interpolate
+    #
+    def interpolate_tensor_iter(self):
+        inputs = self.get_input()
+
+        def _interpolate_tensor_iter():
+            for t in inputs:
+                torch.nn.functional.interpolate(t,  t.unsqueeze(0).shape[-2])
+        return _interpolate_tensor_iter
+
+    def interpolate_tensor_pad(self):
+        inputs = self.get_input(pad=True)
+        stack = torch.stack(inputs)
+
+        def _interpolate_tensor_pad():
+            torch.nn.functional.interpolate(stack, inputs[0].unsqueeze(0).shape[-2])
+
+        return _interpolate_tensor_pad
+
+    def interpolate_nt(self):
+        inputs = self.get_input()
+        nt = nestedtensor.nested_tensor(inputs)
+        def _interpolate_nt():
+            torch.nn.functional.interpolate(nt)
+
+        return _interpolate_nt
+
+
+
+def main(args):
+    b = SegLayersBenchMark(args)
+
+    print(utils.benchmark_fn(b.relu_tensor_iter(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.relu_tensor_pad(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.relu_nt(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.conv2d_tensor_iter(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.conv2d_tensor_pad(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.conv2d_nt(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.batch_norm_tensor_iter(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.batch_norm_tensor_pad(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.batch_norm_nt(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.max_pool2d_tensor_iter(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.max_pool2d_tensor_pad(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.max_pool2d_nt(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.cross_entropy_tensor_iter(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.cross_entropy_tensor_pad(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.cross_entropy_nt(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.dropout_tensor_iter(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.dropout_tensor_pad(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.dropout_nt(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.interpolate_tensor_iter(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.interpolate_tensor_pad(), warmup=b.warmup))
+    print(utils.benchmark_fn(b.interpolate_nt(), warmup=b.warmup))
 
 if __name__ == "__main__":
-    # relu
-    print(utils.benchmark_fn(relu_tensor_tensors_same_size(), warmup=WARM))
-    print(utils.benchmark_fn(relu_nt_tensors_same_size(), warmup=WARM))
-    print(utils.benchmark_fn(relu_tensor_small_diff_pad(), warmup=WARM))
-    print(utils.benchmark_fn(relu_tensor_small_diff_iter(), warmup=WARM))
-    print(utils.benchmark_fn(relu_nt_small_diff(), warmup=WARM))
-    print(utils.benchmark_fn(relu_tensor_big_diff_pad(), warmup=WARM))
-    print(utils.benchmark_fn(relu_tensor_big_diff_iter(), warmup=WARM))
-    print(utils.benchmark_fn(relu_nt_big_diff(), warmup=WARM))
-
-    # conv2d
-    print(utils.benchmark_fn(conv2d_tensor_tensors_same_size(), warmup=WARM))
-    print(utils.benchmark_fn(conv2d_nt_tensors_same_size(), warmup=WARM))
-    print(utils.benchmark_fn(conv2d_tensor_small_diff_pad(), warmup=WARM))
-    print(utils.benchmark_fn(conv2d_tensor_small_diff_iter(), warmup=WARM))
-    print(utils.benchmark_fn(conv2d_nt_small_diff(), warmup=WARM))
-    print(utils.benchmark_fn(conv2d_tensor_big_diff_pad(), warmup=WARM))
-    print(utils.benchmark_fn(conv2d_tensor_big_diff_iter(), warmup=WARM))
-    print(utils.benchmark_fn(conv2d_nt_big_diff(), warmup=WARM))
-
-    # batch_norm
-    print(utils.benchmark_fn(batch_norm_tensor_tensors_same_size(), warmup=WARM))
-    print(utils.benchmark_fn(batch_norm_nt_tensors_same_size(), warmup=WARM))
-    print(utils.benchmark_fn(batch_norm_tensor_small_diff_pad(), warmup=WARM))
-    print(utils.benchmark_fn(batch_norm_tensor_small_diff_iter(), warmup=WARM))
-    print(utils.benchmark_fn(batch_norm_nt_small_diff(), warmup=WARM))  
-    print(utils.benchmark_fn(batch_norm_tensor_big_diff_pad(), warmup=WARM))
-    print(utils.benchmark_fn(batch_norm_tensor_big_diff_iter(), warmup=WARM))
-    print(utils.benchmark_fn(batch_norm_nt_big_diff(), warmup=WARM))
-
-    # max_pool2d
-    print(utils.benchmark_fn(max_pool2d_tensor_tensors_same_size(), warmup=WARM))
-    print(utils.benchmark_fn(max_pool2d_nt_tensors_same_size(), warmup=WARM))
-    print(utils.benchmark_fn(max_pool2d_tensor_small_diff_pad(), warmup=WARM))
-    print(utils.benchmark_fn(max_pool2d_tensor_small_diff_iter(), warmup=WARM))
-    print(utils.benchmark_fn(max_pool2d_nt_small_diff(), warmup=WARM))
-    print(utils.benchmark_fn(max_pool2d_tensor_big_diff_pad(), warmup=WARM))
-    print(utils.benchmark_fn(max_pool2d_tensor_big_diff_iter(), warmup=WARM))
-    print(utils.benchmark_fn(max_pool2d_nt_big_diff(), warmup=WARM))
-
-    # cross_entropy
-    print(utils.benchmark_fn(cross_entropy_tensor_tensors_same_size(), warmup=WARM))
-    print(utils.benchmark_fn(cross_entropy_nt_tensors_same_size(), warmup=WARM))
-    print(utils.benchmark_fn(cross_entropy_tensor_small_diff_pad(), warmup=WARM))
-    print(utils.benchmark_fn(cross_entropy_tensor_small_diff_iter(), warmup=WARM))
-    print(utils.benchmark_fn(cross_entropy_nt_small_diff(), warmup=WARM))
-    print(utils.benchmark_fn(cross_entropy_tensor_big_diff_pad(), warmup=WARM))
-    print(utils.benchmark_fn(cross_entropy_tensor_big_diff_iter(), warmup=WARM))
-    print(utils.benchmark_fn(cross_entropy_nt_big_diff(), warmup=WARM))
-
-    # dropout
-    print(utils.benchmark_fn(dropout_tensor_tensors_same_size(), warmup=WARM))
-    print(utils.benchmark_fn(dropout_nt_tensors_same_size(), warmup=WARM))
-    print(utils.benchmark_fn(dropout_tensor_small_diff_pad(), warmup=WARM))
-    print(utils.benchmark_fn(dropout_tensor_small_diff_iter(), warmup=WARM))
-    print(utils.benchmark_fn(dropout_nt_small_diff(), warmup=WARM))
-    print(utils.benchmark_fn(dropout_tensor_big_diff_pad(), warmup=WARM))
-    print(utils.benchmark_fn(dropout_tensor_big_diff_iter(), warmup=WARM))
-    print(utils.benchmark_fn(dropout_nt_big_diff(), warmup=WARM))
-
-    # interpolate
-    print(utils.benchmark_fn(interpolate_tensor_tensors_same_size(), warmup=WARM))
-    print(utils.benchmark_fn(interpolate_nt_tensors_same_size(), warmup=WARM))
-    print(utils.benchmark_fn(interpolate_tensor_small_diff_pad(), warmup=WARM))
-    print(utils.benchmark_fn(interpolate_tensor_small_diff_iter(), warmup=WARM))
-    print(utils.benchmark_fn(interpolate_nt_small_diff(), warmup=WARM))
-    print(utils.benchmark_fn(interpolate_tensor_big_diff_pad(), warmup=WARM))
-    print(utils.benchmark_fn(interpolate_tensor_big_diff_iter(), warmup=WARM))
-    print(utils.benchmark_fn(interpolate_nt_big_diff(), warmup=WARM))
+    main(sys.argv[1:])

--- a/benchmarks/segmentation_layers.py
+++ b/benchmarks/segmentation_layers.py
@@ -298,32 +298,12 @@ class SegLayersBenchMark(object):
 
         return _interpolate_nt
 
-
-
 def main(args):
-    b = SegLayersBenchMark(args)
-
-    print(utils.benchmark_fn(b.relu_tensor_iter(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.relu_tensor_pad(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.relu_nt(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.conv2d_tensor_iter(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.conv2d_tensor_pad(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.conv2d_nt(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.batch_norm_tensor_iter(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.batch_norm_tensor_pad(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.batch_norm_nt(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.max_pool2d_tensor_iter(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.max_pool2d_tensor_pad(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.max_pool2d_nt(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.cross_entropy_tensor_iter(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.cross_entropy_tensor_pad(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.cross_entropy_nt(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.dropout_tensor_iter(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.dropout_tensor_pad(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.dropout_nt(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.interpolate_tensor_iter(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.interpolate_tensor_pad(), warmup=b.warmup))
-    print(utils.benchmark_fn(b.interpolate_nt(), warmup=b.warmup))
+    assert len(args) == 7
+    name = args[0]
+    benchmark_obj = SegLayersBenchMark(args[1:])
+    benchmark = getattr(benchmark_obj, name)
+    print(utils.benchmark_fn(benchmark(), warmup=benchmark_obj.warmup))
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/benchmarks/segmentation_layers.py
+++ b/benchmarks/segmentation_layers.py
@@ -7,7 +7,7 @@ import random
 
 class SegLayersBenchMark(object):
     def __init__(self, args):
-        assert len(args) == 10
+        assert len(args) == 8
         print("Called with args: ")
         
         self.N = int(args[0])
@@ -22,22 +22,16 @@ class SegLayersBenchMark(object):
         self.W = int(args[3])
         print("W = ", self.W)
         
-        self.mu_h = int(args[4])
-        print("mu_h = ", self.mu_h)
-
-        self.var_h = int(args[5])
+        self.var_h = int(args[4])
         print("var_h = ", self.var_h)
 
-        self.mu_w = int(args[6])
-        print("mu_w = ", self.mu_w)
-
-        self.var_w = int(args[7])
+        self.var_w = int(args[5])
         print("var_w = ", self.var_w)
         
-        self.seed = int(args[8])
+        self.seed = int(args[6])
         print("seed = ", self.seed)
 
-        self.warmup = float(args[9])
+        self.warmup = float(args[7])
         print("warmup = ", self.warmup)
         
         self.conv2d = torch.nn.Conv2d(self.C, 3, kernel_size= (1, 1), bias=False)
@@ -93,8 +87,8 @@ class SegLayersBenchMark(object):
         
         torch.manual_seed(self.seed)
         for i in range(self.N):
-            h_delta = random.gauss(self.mu_h, self.var_h)
-            w_delta = random.gauss(self.mu_w, self.var_w)
+            h_delta = random.gauss(self.H, self.var_h)
+            w_delta = random.gauss(self.H, self.var_w)
             h = int(self.H + h_delta)
             w = int(self.W + w_delta)
             inputs.append(torch.randn(self.C, h, w))
@@ -315,7 +309,7 @@ class SegLayersBenchMark(object):
         return _interpolate_nt
 
 def main(args):
-    assert len(args) == 11
+    assert len(args) == 9
     name = args[0]
     benchmark_obj = SegLayersBenchMark(args[1:])
     benchmark = getattr(benchmark_obj, name)

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -44,8 +44,11 @@ def benchmark_fn(fn, run_time = 5.0, use_cprofile=False, warmup=1.0):
         sortby = SortKey.CUMULATIVE
         ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
         ps.print_stats()
-    result = ""
-    result +=  "fn {:<15} avg(us): {:10.4f} std(us): {:10.4f} num_runs: {}".format(fn.__name__, times.mean().item(), times.std().item(), len(times))
+    result = {}
+    result['name'] = fn.__name__
+    result['avg_us'] = times.mean().item()
+    result['std_us'] = times.std().item()
+    result['runs'] = len(times)
     if use_cprofile:
-        result += s.getvalue()
+        result['cprofile'] = s.getvalue()
     return result

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.0.1.dev202041422+f266219'
-git_version = 'f266219de6daca23be50dd0f12df0a892c96b830'
+__version__ = '0.0.1.dev202041019+aed36d5'
+git_version = 'aed36d50607a42109e03f0e533ba4e2d208a8272'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION


### PR DESCRIPTION
Added benchmarking for segmentation pipeline layers. 
Example of usage: 

`>>> clear && python benchmarks/segmentation_layers.py -L relu_tensor_pad relu_nt -N 10 -C 3 -W 100 -H 100 -HV 10 11 -WV 10  11 -S 24 -WARM 0.0`

```
<<<
called with:  Namespace(C=3, H=100, HV=[10, 11], N=10, W=100, WV=[10, 11], layers=['relu_tensor_pad', 'relu_nt'], seed=[24], warm=0.0)
_relu_tensor_pad , 505.16448974609375 , 23.60953140258789 , 9898 , 10 , 10 , 24
_relu_nt , 526.1130981445312 , 18.652135848999023 , 9504 , 10 , 10 , 24
_relu_tensor_pad , 493.748779296875 , 15.7689847946167 , 10127 , 10 , 11 , 24
_relu_nt , 526.4400634765625 , 29.80328941345215 , 9498 , 10 , 11 , 24
_relu_tensor_pad , 481.2615051269531 , 21.609426498413086 , 10390 , 11 , 10 , 24
_relu_nt , 580.851806640625 , 42.515838623046875 , 8609 , 11 , 10 , 24
_relu_tensor_pad , 491.73590087890625 , 62.527915954589844 , 10169 , 11 , 11 , 24
_relu_nt , 568.2987670898438 , 91.61013793945312 , 8799 , 11 , 11 , 24
```