### PR TITLE
Segmentation benchmark follow-up fixes

### DIFF
--- a/benchmarks/segmentation_layers.py
+++ b/benchmarks/segmentation_layers.py
@@ -227,32 +227,34 @@ class SegLayersBenchMark(object):
         self.layers = {}
 
     def get_benchmark(self, channels, name):
+        layer = None
         if name.startswith("conv2d"):
             m = re.match(r"conv2d_([a-z]+)_(\d+)x(\d+)", name)
             if m is None:
                 raise ValueError("Unsupported parameterization for conv2d layer {}".format(name))
             benchmark_kind = m.group(1)
-            print(benchmark_kind)
             k0 = int(m.group(2))
             k1 = int(m.group(3))
             layer = self.layers.setdefault(
                 name, torch.nn.Conv2d(channels, 3, kernel_size=(k0, k1), bias=False)
             )
-            return getattr(Benchmarks, "conv2d_" + benchmark_kind)(self, layer)
+            name = "conv2d_" + benchmark_kind
         if name.startswith("batch_norm"):
-            return self.layers.setdefault(
+            layer = setdefault(
                 name, torch.nn.BatchNorm2d(channels, 1e-05, 0.1).eval()
             )
-            return getattr(Benchmarks, name)(self)
         if name.startswith("max_pool2d"):
-            return self.layers.setdefault(
+            layer = self.layers.setdefault(
                 name,
                 torch.nn.MaxPool2d(
                     kernel_size=(2, 2), stride=(2, 2), padding=(0, 0), dilation=(1, 1)
                 ),
             )
-            return getattr(Benchmarks, name)(self)
-        return getattr(Benchmarks, name)(self)
+        try:
+            return Benchmarks[name](self) if layer is None else Benchmarks[name](self, layer)
+        except AttributeError:
+            raise ValueError("Benchmark {} is not supported. Available benchmarks are\n{}.".format(layer,
+                "\n".join(Benchmarks.keys())))
 
     def run(self):
         for n, c, h, w, h_var, w_var, seed in itertools.product(
@@ -268,16 +270,9 @@ class SegLayersBenchMark(object):
             # generate inputs before iterating layers to have the same imput per layer
             self.inputs, self.targets = self.get_input(n, c, h, w, h_var, w_var, seed)
 
-            benchmarks = []
-            for layer in self.args.layers:
-                try:
-                    benchmark = self.get_benchmark(c, layer)
-                except AttributeError:
-                    raise ValueError("Benchmark {} is not supported. Available benchmarks are\n{}.".format(layer,
-                        "\n".join(Benchmarks.keys())))
-                benchmarks.append(benchmark)
+            benchmarks = [(layer, self.get_benchmark(c, layer)) for layer in self.args.layers]
 
-            for benchmark in benchmarks:
+            for layer, benchmark in benchmarks:
                 result = utils.benchmark_fn(benchmark, warmup=self.args.warm)
                 result["N"] = n
                 result["C"] = c
@@ -288,6 +283,7 @@ class SegLayersBenchMark(object):
                 result["seed"] = seed
                 result["avg_us"] = int(result["avg_us"])
                 result["std_us"] = int(result["std_us"])
+                result["name"] = layer
 
                 print(
                     ",".join(

--- a/benchmarks/segmentation_layers.py
+++ b/benchmarks/segmentation_layers.py
@@ -68,7 +68,7 @@ def conv2d_nt(self, module):
     nt = nestedtensor.nested_tensor(self.inputs)
 
     def _conv2d():
-        self.conv2d(nt)
+        module(nt)
 
     return _conv2d
 

--- a/benchmarks/segmentation_layers.py
+++ b/benchmarks/segmentation_layers.py
@@ -269,7 +269,8 @@ class SegLayersBenchMark(object):
                 try:
                     benchmark = self.get_benchmark(c, layer)
                 except AttributeError:
-                    raise ValueError("Benchmark {} is not supported".format(layer))
+                    raise ValueError("Benchmark {} is not supported. Available benchmarks are {}.".format(layer,
+                        dir(Benchmarks)))
                 benchmarks.append(benchmark)
 
             for benchmark in benchmarks:

--- a/benchmarks/segmentation_layers.py
+++ b/benchmarks/segmentation_layers.py
@@ -264,11 +264,15 @@ class SegLayersBenchMark(object):
             # generate inputs before iterating layers to have the same imput per layer
             self.inputs, self.targets = self.get_input(n, c, h, w, h_var, w_var, seed)
 
+            benchmarks = []
             for layer in self.args.layers:
-                benchmark = self.get_benchmark(c, layer)
-                print('benchmark')
-                print(benchmark)
+                try:
+                    benchmark = self.get_benchmark(c, layer)
+                except AttributeError:
+                    raise ValueError("Benchmark {} is not supported".format(layer))
+                benchmarks.append(benchmark)
 
+            for benchmark in benchmarks:
                 result = utils.benchmark_fn(benchmark, warmup=self.args.warm)
                 result["N"] = n
                 result["C"] = c

--- a/benchmarks/segmentation_layers.py
+++ b/benchmarks/segmentation_layers.py
@@ -9,213 +9,217 @@ import itertools
 import re
 
 
-class Benchmarks(object):
-    #
-    # relu
-    #
-    @staticmethod
-    def relu_tensor_iter(self):
-        def _relu_tensor_iter():
-            for t in self.inputs:
-                torch.nn.functional.relu(t)
+Benchmarks = {}
 
-        return _relu_tensor_iter
+def register_benchmark(fn):
+    Benchmarks[fn.__name__] = fn
 
-    @staticmethod
-    def relu_tensor_pad(self):
-        tensor, _ = nestedtensor.nested_tensor(self.inputs).to_tensor_mask()
+#
+# relu
+#
+@register_benchmark
+def relu_tensor_iter(self):
+    def _relu_tensor_iter():
+        for t in self.inputs:
+            torch.nn.functional.relu(t)
 
-        def _relu_tensor_pad():
-            torch.nn.functional.relu(tensor)
+    return _relu_tensor_iter
 
-        return _relu_tensor_pad
+@register_benchmark
+def relu_tensor_pad(self):
+    tensor, _ = nestedtensor.nested_tensor(self.inputs).to_tensor_mask()
 
-    @staticmethod
-    def relu_nt(self):
-        nt = nestedtensor.nested_tensor(self.inputs)
+    def _relu_tensor_pad():
+        torch.nn.functional.relu(tensor)
 
-        def _relu_nt():
-            torch.nn.functional.relu(nt)
+    return _relu_tensor_pad
 
-        return _relu_nt
+@register_benchmark
+def relu_nt(self):
+    nt = nestedtensor.nested_tensor(self.inputs)
 
-    #
-    # conv2d
-    #
-    @staticmethod
-    def conv2d_iter(self, module):
-        def _conv2d_tensor_iter():
-            for t in self.inputs:
-                module(t.unsqueeze(0)).squeeze(0)
+    def _relu_nt():
+        torch.nn.functional.relu(nt)
 
-        return _conv2d_tensor_iter
+    return _relu_nt
 
-    @staticmethod
-    def conv2d_pad(self, module):
-        tensor, _ = nestedtensor.nested_tensor(self.inputs).to_tensor_mask()
+#
+# conv2d
+#
+@register_benchmark
+def conv2d_iter(self, module):
+    def _conv2d_tensor_iter():
+        for t in self.inputs:
+            module(t.unsqueeze(0)).squeeze(0)
 
-        def _conv2d_tensor():
-            module(tensor)
+    return _conv2d_tensor_iter
 
-        return _conv2d_tensor
+@register_benchmark
+def conv2d_pad(self, module):
+    tensor, _ = nestedtensor.nested_tensor(self.inputs).to_tensor_mask()
 
-    @staticmethod
-    def conv2d_nt(self, module):
-        nt = nestedtensor.nested_tensor(self.inputs)
+    def _conv2d_tensor():
+        module(tensor)
 
-        def _conv2d():
-            self.conv2d(nt)
+    return _conv2d_tensor
 
-        return _conv2d
+@register_benchmark
+def conv2d_nt(self, module):
+    nt = nestedtensor.nested_tensor(self.inputs)
 
-    #
-    # batch_norm
-    #
-    @staticmethod
-    def batch_norm_tensor_iter(self):
-        def _batch_norm_tensor_iter():
-            for t in self.inputs:
-                self.batch_norm(t.unsqueeze(0)).squeeze(0)
+    def _conv2d():
+        self.conv2d(nt)
 
-        return _batch_norm_tensor_iter
+    return _conv2d
 
-    @staticmethod
-    def batch_norm_tensor_pad(self):
-        tensor, _ = nestedtensor.nested_tensor(self.inputs).to_tensor_mask()
+#
+# batch_norm
+#
+@register_benchmark
+def batch_norm_tensor_iter(self):
+    def _batch_norm_tensor_iter():
+        for t in self.inputs:
+            self.batch_norm(t.unsqueeze(0)).squeeze(0)
 
-        def _batch_norm_tensor_pad():
-            self.batch_norm(tensor)
+    return _batch_norm_tensor_iter
 
-        return _batch_norm_tensor_pad
+@register_benchmark
+def batch_norm_tensor_pad(self):
+    tensor, _ = nestedtensor.nested_tensor(self.inputs).to_tensor_mask()
 
-    @staticmethod
-    def batch_norm_nt(self):
-        nt = nestedtensor.nested_tensor(self.inputs)
+    def _batch_norm_tensor_pad():
+        self.batch_norm(tensor)
 
-        def _batch_norm_nt():
-            self.batch_norm(nt)
+    return _batch_norm_tensor_pad
 
-        return _batch_norm_nt
+@register_benchmark
+def batch_norm_nt(self):
+    nt = nestedtensor.nested_tensor(self.inputs)
 
-    #
-    # max_pool2d
-    #
-    @staticmethod
-    def max_pool2d_tensor_iter(self):
-        def _max_pool2d_tensor_iter():
-            for t in self.inputs:
-                self.max_pool2d(t.unsqueeze(0)).squeeze(0)
+    def _batch_norm_nt():
+        self.batch_norm(nt)
 
-        return _max_pool2d_tensor_iter
+    return _batch_norm_nt
 
-    @staticmethod
-    def max_pool2d_tensor_pad(self):
-        tensor, _ = nestedtensor.nested_tensor(self.inputs).to_tensor_mask()
+#
+# max_pool2d
+#
+@register_benchmark
+def max_pool2d_tensor_iter(self):
+    def _max_pool2d_tensor_iter():
+        for t in self.inputs:
+            self.max_pool2d(t.unsqueeze(0)).squeeze(0)
 
-        def _max_pool2d_tensor_pad():
-            self.max_pool2d(tensor)
+    return _max_pool2d_tensor_iter
 
-        return _max_pool2d_tensor_pad
+@register_benchmark
+def max_pool2d_tensor_pad(self):
+    tensor, _ = nestedtensor.nested_tensor(self.inputs).to_tensor_mask()
 
-    @staticmethod
-    def max_pool2d_nt(self):
-        nt = nestedtensor.nested_tensor(self.inputs)
+    def _max_pool2d_tensor_pad():
+        self.max_pool2d(tensor)
 
-        def _max_pool2d_nt():
-            self.max_pool2d(nt)
+    return _max_pool2d_tensor_pad
 
-        return _max_pool2d_nt
+@register_benchmark
+def max_pool2d_nt(self):
+    nt = nestedtensor.nested_tensor(self.inputs)
 
-    #
-    # cross_entropy
-    #
-    @staticmethod
-    def cross_entropy_tensor_iter(self):
-        def _cross_entropy_tensor_iter():
-            for a, b in zip(self.inputs, self.targets):
-                torch.nn.functional.cross_entropy(
-                    a.unsqueeze(0), b.unsqueeze(0)
-                ).squeeze(0)
+    def _max_pool2d_nt():
+        self.max_pool2d(nt)
 
-        return _cross_entropy_tensor_iter
+    return _max_pool2d_nt
 
-    @staticmethod
-    def cross_entropy_tensor_pad(self):
-        tensor, _ = nestedtensor.nested_tensor(self.inputs).to_tensor_mask()
-        targets = torch.stack(self.targets)
+#
+# cross_entropy
+#
+@register_benchmark
+def cross_entropy_tensor_iter(self):
+    def _cross_entropy_tensor_iter():
+        for a, b in zip(self.inputs, self.targets):
+            torch.nn.functional.cross_entropy(
+                a.unsqueeze(0), b.unsqueeze(0)
+            ).squeeze(0)
 
-        def _cross_entropy_tensor_pad():
-            torch.nn.functional.cross_entropy(tensor, targets)
+    return _cross_entropy_tensor_iter
 
-        return _cross_entropy_tensor_pad
+@register_benchmark
+def cross_entropy_tensor_pad(self):
+    tensor, _ = nestedtensor.nested_tensor(self.inputs).to_tensor_mask()
+    targets = torch.stack(self.targets)
 
-    @staticmethod
-    def cross_entropy_nt(self):
-        nt_input = nestedtensor.nested_tensor(self.inputs)
-        nt_targets = nestedtensor.nested_tensor(self.targets)
+    def _cross_entropy_tensor_pad():
+        torch.nn.functional.cross_entropy(tensor, targets)
 
-        def _cross_entropy_nt():
-            torch.nn.functional.cross_entropy(nt_input, nt_targets)
+    return _cross_entropy_tensor_pad
 
-        return _cross_entropy_nt
+@register_benchmark
+def cross_entropy_nt(self):
+    nt_input = nestedtensor.nested_tensor(self.inputs)
+    nt_targets = nestedtensor.nested_tensor(self.targets)
 
-    #
-    # dropout
-    #
-    @staticmethod
-    def dropout_tensor_iter(self):
-        def _dropout_tensor_iter():
-            for t in self.inputs:
-                torch.nn.functional.dropout(t.unsqueeze(0)).squeeze(0)
+    def _cross_entropy_nt():
+        torch.nn.functional.cross_entropy(nt_input, nt_targets)
 
-        return _dropout_tensor_iter
+    return _cross_entropy_nt
 
-    @staticmethod
-    def dropout_tensor_pad(self):
-        tensor, _ = nestedtensor.nested_tensor(self.inputs).to_tensor_mask()
+#
+# dropout
+#
+@register_benchmark
+def dropout_tensor_iter(self):
+    def _dropout_tensor_iter():
+        for t in self.inputs:
+            torch.nn.functional.dropout(t.unsqueeze(0)).squeeze(0)
 
-        def _dropout_tensor_pad():
-            torch.nn.functional.dropout(tensor)
+    return _dropout_tensor_iter
 
-        return _dropout_tensor_pad
+@register_benchmark
+def dropout_tensor_pad(self):
+    tensor, _ = nestedtensor.nested_tensor(self.inputs).to_tensor_mask()
 
-    @staticmethod
-    def dropout_nt(self):
-        nt = nestedtensor.nested_tensor(self.inputs)
+    def _dropout_tensor_pad():
+        torch.nn.functional.dropout(tensor)
 
-        def _dropout_nt():
-            torch.nn.functional.dropout(nt)
+    return _dropout_tensor_pad
 
-        return _dropout_nt
+@register_benchmark
+def dropout_nt(self):
+    nt = nestedtensor.nested_tensor(self.inputs)
 
-    #
-    # interpolate
-    #
-    @staticmethod
-    def interpolate_tensor_iter(self):
-        def _interpolate_tensor_iter():
-            for t in self.inputs:
-                torch.nn.functional.interpolate(t, t.unsqueeze(0).shape[-2])
+    def _dropout_nt():
+        torch.nn.functional.dropout(nt)
 
-        return _interpolate_tensor_iter
+    return _dropout_nt
 
-    @staticmethod
-    def interpolate_tensor_pad(self):
-        tensor, _ = nestedtensor.nested_tensor(self.inputs).to_tensor_mask()
+#
+# interpolate
+#
+@register_benchmark
+def interpolate_tensor_iter(self):
+    def _interpolate_tensor_iter():
+        for t in self.inputs:
+            torch.nn.functional.interpolate(t, t.unsqueeze(0).shape[-2])
 
-        def _interpolate_tensor_pad():
-            torch.nn.functional.interpolate(tensor, tensor[0].unsqueeze(0).shape[-2])
+    return _interpolate_tensor_iter
 
-        return _interpolate_tensor_pad
+@register_benchmark
+def interpolate_tensor_pad(self):
+    tensor, _ = nestedtensor.nested_tensor(self.inputs).to_tensor_mask()
 
-    @staticmethod
-    def interpolate_nt(self):
-        nt = nestedtensor.nested_tensor(self.inputs)
+    def _interpolate_tensor_pad():
+        torch.nn.functional.interpolate(tensor, tensor[0].unsqueeze(0).shape[-2])
 
-        def _interpolate_nt():
-            torch.nn.functional.interpolate(nt)
+    return _interpolate_tensor_pad
 
-        return _interpolate_nt
+@register_benchmark
+def interpolate_nt(self):
+    nt = nestedtensor.nested_tensor(self.inputs)
+
+    def _interpolate_nt():
+        torch.nn.functional.interpolate(nt)
+
+    return _interpolate_nt
 
 class SegLayersBenchMark(object):
     def __init__(self, args):
@@ -226,7 +230,7 @@ class SegLayersBenchMark(object):
         if name.startswith("conv2d"):
             m = re.match(r"conv2d_([a-z]+)_(\d+)x(\d+)", name)
             if m is None:
-                raise ValueError("Unsupported conv2d layer {}".format(name))
+                raise ValueError("Unsupported parameterization for conv2d layer {}".format(name))
             benchmark_kind = m.group(1)
             print(benchmark_kind)
             k0 = int(m.group(2))
@@ -269,8 +273,8 @@ class SegLayersBenchMark(object):
                 try:
                     benchmark = self.get_benchmark(c, layer)
                 except AttributeError:
-                    raise ValueError("Benchmark {} is not supported. Available benchmarks are {}.".format(layer,
-                        dir(Benchmarks)))
+                    raise ValueError("Benchmark {} is not supported. Available benchmarks are\n{}.".format(layer,
+                        "\n".join(Benchmarks.keys())))
                 benchmarks.append(benchmark)
 
             for benchmark in benchmarks:


### PR DESCRIPTION
Few changes I missed...

```
(source) ➜  nestedtensor git:(up3) ✗ python benchmarks/segmentation_layers.py -L conv2d_nt_1x1 conv2d_iter_3x3 relu_tensor_pad batch_norm_tensor_iter max_pool2d_nt -N 20 -C 3 -H 100 -W 100 -HV 0 10 -WV 0 -S 24 -WARM 2
('C', 3),('H', 100),('N', 20),('W', 100),('avg_us', 28559),('h_var', 0),('name', 'conv2d_nt_1x1'),('runs', 176),('seed', 24),('std_us', 4113),('w_var', 0)
('C', 3),('H', 100),('N', 20),('W', 100),('avg_us', 21018),('h_var', 0),('name', 'conv2d_iter_3x3'),('runs', 238),('seed', 24),('std_us', 2216),('w_var', 0)
('C', 3),('H', 100),('N', 20),('W', 100),('avg_us', 887),('h_var', 0),('name', 'relu_tensor_pad'),('runs', 5632),('seed', 24),('std_us', 176),('w_var', 0)
('C', 3),('H', 100),('N', 20),('W', 100),('avg_us', 1398),('h_var', 0),('name', 'batch_norm_tensor_iter'),('runs', 3576),('seed', 24),('std_us', 197),('w_var', 0)
('C', 3),('H', 100),('N', 20),('W', 100),('avg_us', 11830),('h_var', 0),('name', 'max_pool2d_nt'),('runs', 423),('seed', 24),('std_us', 969),('w_var', 0)
('C', 3),('H', 100),('N', 20),('W', 100),('avg_us', 29217),('h_var', 10),('name', 'conv2d_nt_1x1'),('runs', 172),('seed', 24),('std_us', 2066),('w_var', 0)
('C', 3),('H', 100),('N', 20),('W', 100),('avg_us', 23193),('h_var', 10),('name', 'conv2d_iter_3x3'),('runs', 216),('seed', 24),('std_us', 2264),('w_var', 0)
('C', 3),('H', 100),('N', 20),('W', 100),('avg_us', 928),('h_var', 10),('name', 'relu_tensor_pad'),('runs', 5388),('seed', 24),('std_us', 109),('w_var', 0)
('C', 3),('H', 100),('N', 20),('W', 100),('avg_us', 1281),('h_var', 10),('name', 'batch_norm_tensor_iter'),('runs', 3903),('seed', 24),('std_us', 131),('w_var', 0)
('C', 3),('H', 100),('N', 20),('W', 100),('avg_us', 12055),('h_var', 10),('name', 'max_pool2d_nt'),('runs', 415),('seed', 24),('std_us', 1061),('w_var', 0)
```