### PR TITLE
Change as_nested_tensor to only forward NestedTensor type

### DIFF
--- a/nestedtensor/csrc/creation.cpp
+++ b/nestedtensor/csrc/creation.cpp
@@ -182,7 +182,7 @@ NestedNode<c10::IValue> py_to_nested_tensor(const py::object& py_obj) {
   }
 }
 
-THPNestedTensor as_nested_tensor(py::sequence list) {
+THPNestedTensor nested_tensor(py::sequence list) {
   NestedNode<c10::IValue> ivalue_structure = py_to_nested_tensor(list);
   auto fn = [](c10::IValue a, bool result) { return result && a.isTensor(); };
   bool all_same =
@@ -197,7 +197,7 @@ THPNestedTensor as_nested_tensor(py::sequence list) {
       _verify_variables(*first, structure, true);
     }
   }
-  return THPNestedTensor(NestedTensor(std::move(structure)));
+  return THPNestedTensor(NestedTensor(std::move(structure))).contiguous();
 }
 
 } // namespace nested_tensor

--- a/nestedtensor/csrc/creation.cpp
+++ b/nestedtensor/csrc/creation.cpp
@@ -197,7 +197,7 @@ THPNestedTensor nested_tensor(py::sequence list) {
       _verify_variables(*first, structure, true);
     }
   }
-  return THPNestedTensor(NestedTensor(std::move(structure))).contiguous();
+  return THPNestedTensor(NestedTensor(std::move(structure)).contiguous());
 }
 
 } // namespace nested_tensor

--- a/nestedtensor/csrc/creation.h
+++ b/nestedtensor/csrc/creation.h
@@ -6,7 +6,7 @@ namespace nested_tensor {
 
 NestedNode<py::object> py_to_nested_node(py::object&& py_obj);
 
-THPNestedTensor as_nested_tensor(pybind11::sequence list);
+THPNestedTensor nested_tensor(pybind11::sequence list);
 
 } // namespace nested_tensor
 } // namespace torch

--- a/nestedtensor/csrc/functions.cpp
+++ b/nestedtensor/csrc/functions.cpp
@@ -67,10 +67,10 @@ NestedTensor relu(NestedTensor& input,
                   c10::optional<bool> inplace) {
   if (input.is_contiguous()) {
     if (inplace.has_value() && inplace.value()) {
-      input = NestedTensor(std::move(torch::relu(*input.get_buffer())), input.nested_size());
+      input = NestedTensor(torch::relu(*input.get_buffer()), input.nested_size());
       return input;
     }
-    return NestedTensor(std::move(torch::relu(*input.get_buffer())), input.nested_size());
+    return NestedTensor(torch::relu(*input.get_buffer()), input.nested_size());
   }
 
   TensorNode input_structure = input.get_structure();

--- a/nestedtensor/csrc/py_init.cpp
+++ b/nestedtensor/csrc/py_init.cpp
@@ -91,5 +91,5 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 
   // NOTE: This is a private function until it is feature complete
   m.def("_jit_tensorwise", &torch::nested_tensor::jit_tensorwise);
-  m.def("as_nested_tensor", &torch::nested_tensor::as_nested_tensor);
+  m.def("nested_tensor", &torch::nested_tensor::nested_tensor);
 }

--- a/nestedtensor/nested/creation.py
+++ b/nestedtensor/nested/creation.py
@@ -9,13 +9,9 @@ def as_nested_tensor(data, dtype=None, device=None):
     # Simple wrapper around a nested list of Tensors.
     # Shares memory with original objects.
     # # TODO: Needs tests to check failure cases
-    ret_impl = _C.as_nested_tensor(data)
-    ret = nested.NestedTensor(ret_impl)
-    if dtype is not None:
-        ret = ret.to(dtype)
-    if device is not None:
-        ret = ret.to(device)
-    return ret
+    if utils.is_nested_tensor(data):
+        return data
+    return nested_tensor(data, dtype, device)
 
 def nested_tensor(data, dtype=None, device=None, requires_grad=False, pin_memory=False):
     """

--- a/nestedtensor/nested/creation.py
+++ b/nestedtensor/nested/creation.py
@@ -10,7 +10,7 @@ def nested_tensor(data, dtype=None, device=None, requires_grad=False, pin_memory
     """
     Arguments match torch.tensor
     """
-    result = as_nested_tensor(data).contiguous()
+    result = _C.nested_tensor(data)
 
     if dtype is not None or device is not None:
         result = result.to(dtype=dtype, device=device)

--- a/nestedtensor/nested/creation.py
+++ b/nestedtensor/nested/creation.py
@@ -10,7 +10,7 @@ def nested_tensor(data, dtype=None, device=None, requires_grad=False, pin_memory
     """
     Arguments match torch.tensor
     """
-    result = _C.nested_tensor(data)
+    result = nested.NestedTensor(_C.nested_tensor(data))
 
     if dtype is not None or device is not None:
         result = result.to(dtype=dtype, device=device)

--- a/nestedtensor/nested/creation.py
+++ b/nestedtensor/nested/creation.py
@@ -5,13 +5,6 @@ from . import nested
 from . import utils
 from nestedtensor import _C
 
-def as_nested_tensor(data, dtype=None, device=None):
-    # Simple wrapper around a nested list of Tensors.
-    # Shares memory with original objects.
-    # # TODO: Needs tests to check failure cases
-    if utils.is_nested_tensor(data):
-        return data
-    return nested_tensor(data, dtype, device)
 
 def nested_tensor(data, dtype=None, device=None, requires_grad=False, pin_memory=False):
     """
@@ -26,3 +19,12 @@ def nested_tensor(data, dtype=None, device=None, requires_grad=False, pin_memory
     if pin_memory:
         result = result.pin_memory()
     return result
+
+
+def as_nested_tensor(data, dtype=None, device=None):
+    # TODO: Needs tests to check failure cases
+    if not utils.is_nested_tensor(data):
+        data = nested_tensor(data, dtype, device)
+    if dtype is not None or device is not None:
+        return data.to(dtype=dtype, device=device)
+    return data

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.0.1.dev202052020+0f7ff52'
-git_version = '0f7ff52b180474623b39e84631571a4d046fce98'
+__version__ = '0.0.1.dev202052020+fed9991'
+git_version = 'fed99911848c4c30fa6a2fc85f012f5eb4587699'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.0.1.dev202051521+6d43318'
-git_version = '6d4331855c798f2c8531aacf130fbe55be47c471'
+__version__ = '0.0.1.dev202052020+0f7ff52'
+git_version = '0f7ff52b180474623b39e84631571a4d046fce98'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.0.1.dev202052020+b9fcbb0'
-git_version = 'b9fcbb0bf8f205934a493d8bd308c69bd09c9d2e'
+__version__ = '0.0.1.dev202052023+2de5c5f'
+git_version = '2de5c5fb95e5fdc06d1d38ba14bf47d2d31c8f7e'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/test/test_nested_tensor_autograd.py
+++ b/test/test_nested_tensor_autograd.py
@@ -25,8 +25,8 @@ class TestNestedTensorAutograd(TestCase):
         nt_sum_res = some_func(nt)
         nt_sum_res.backward()
         self.assertEqual(sum_res, nt_sum_res)
-        self.assertEqual(verification_tensor.grad.data, nt[0].grad.data)
-        self.assertEqual(verification_tensor.grad.data, tensor.grad.data)
+        self.assertIsNone(nt[0].grad)
+        self.assertIsNotNone(verification_tensor.grad)
 
         # nested_tensor constructor
         tensor2 = torch.tensor([[1, 2], [3, 4]], dtype=torch.float, requires_grad=True)
@@ -55,9 +55,9 @@ class TestNestedTensorAutograd(TestCase):
         sum_res.backward()
 
         self.assertEqual(sum_res, nt_sum_res)
-        self.assertEqual(nt1[0].grad.data, tensor.grad[0].data)
-        self.assertEqual(nt1[1].grad.data, tensor.grad[1].data.masked_select(mask[1]))
-        self.assertEqual(nt1[2].grad.data, tensor.grad[2].data.masked_select(mask[2]))
+        self.assertIsNone(nt1[0].grad)
+        self.assertIsNone(nt1[1].grad)
+        self.assertIsNone(nt1[2].grad)
 
         self.assertIsNone(nt2[0].grad)
         self.assertIsNone(nt2[1].grad)

--- a/test/test_nested_tensor_class.py
+++ b/test/test_nested_tensor_class.py
@@ -57,7 +57,7 @@ class TestNestedTensor(TestCase):
             self.assertNotEqual(tensors[i].storage().data_ptr(
             ), nested_tensor.unbind()[i].storage().data_ptr())
 
-    def test_mutation(self):
+    def test_as_nested_tensor(self):
         tensors = []
         num_tensors = 16
         for i in range(num_tensors):
@@ -76,6 +76,11 @@ class TestNestedTensor(TestCase):
             tensors[i].mul_(i + 2)
         for i in range(num_tensors):
             self.assertNotEqual(tensors[i], nested_tensor.unbind()[i])
+
+        nested_tensor1 = nestedtensor.as_nested_tensor(nested_tensor)
+        self.assertTrue(nested_tensor1 is nested_tensor)
+        nested_tensor2 = nestedtensor.as_nested_tensor(nested_tensor, dtype=torch.int64)
+        self.assertTrue(nested_tensor2 is not nested_tensor)
 
     def test_constructor(self):
         for constructor in _iter_constructors():

--- a/test/test_nested_tensor_functional.py
+++ b/test/test_nested_tensor_functional.py
@@ -184,7 +184,7 @@ class TestFunctional(TestCase):
         nt1 = nestedtensor.as_nested_tensor([t_clone])
         torch.nn.functional.relu_(nt1)
         self.assertEqual(nt1, expected_nt)
-        self.assertEqual(t_clone, expected_t)
+        self.assertNotEqual(t_clone, expected_t)
 
     def test_nn_relu(self):
         inputs = [


### PR DESCRIPTION
Resolves issue https://github.com/pytorch/nestedtensor/issues/150

as_nested_tensor now forwards NestedTensors only. This gets rid of the current view semantics of as_nested_tensor.