### PR TITLE
Updated contiguousity test

### DIFF
--- a/nestedtensor/csrc/functions.cpp
+++ b/nestedtensor/csrc/functions.cpp
@@ -83,7 +83,7 @@ NestedTensor relu(NestedTensor& input,
         return torch::relu(t);
     }, input_structure);
 
-    return NestedTensor(std::move(res));
+    return NestedTensor(std::move(res)).contiguous();
   }
 }
 
@@ -100,7 +100,7 @@ NestedTensor dropout(NestedTensor& input,
       return torch::dropout(t, p.value(), training.value());
   }, input_structure);
 
-  return NestedTensor(std::move(res));
+  return NestedTensor(std::move(res)).contiguous();
 }
 
 NestedTensor conv2d(NestedTensor& input, 
@@ -123,7 +123,7 @@ NestedTensor conv2d(NestedTensor& input,
       return F::conv2d(t.unsqueeze(0), weight, options).squeeze(0);
   }, structure);
 
-  return NestedTensor(std::move(res));
+  return NestedTensor(std::move(res)).contiguous();
 }
 
 NestedTensor max_pool2d(NestedTensor& input,
@@ -142,7 +142,7 @@ NestedTensor max_pool2d(NestedTensor& input,
       return F::max_pool2d(t.unsqueeze(0), options).squeeze(0);
   }, structure);
 
-  return NestedTensor(std::move(res));
+  return NestedTensor(std::move(res)).contiguous();
 }
 
 NestedTensor batch_norm(NestedTensor& input,
@@ -171,7 +171,7 @@ NestedTensor batch_norm(NestedTensor& input,
         return F::batch_norm(t.unsqueeze(0), running_mean, running_var, options).squeeze(0);
     }, structure);
 
-    return NestedTensor(std::move(res));
+    return NestedTensor(std::move(res)).contiguous();
 }
 
 NestedTensor cross_entropy(NestedTensor& input,
@@ -201,7 +201,7 @@ NestedTensor cross_entropy(NestedTensor& input,
       return F::cross_entropy(input_tensor.unsqueeze(0), target_tensor.unsqueeze(0), options).squeeze(0);
   }, input_structure, target_structure);
 
-  return NestedTensor(std::move(res));
+  return NestedTensor(std::move(res)).contiguous();
 }
 
 NestedTensor interpolate(NestedTensor& input,
@@ -241,7 +241,7 @@ NestedTensor interpolate(NestedTensor& input,
           return F::interpolate(input_tensor.unsqueeze(0), options).squeeze(0);
         },
         input_structure);
-      return NestedTensor(std::move(res));
+      return NestedTensor(std::move(res)).contiguous();
     }
 
     // Get input leaves count
@@ -263,7 +263,7 @@ NestedTensor interpolate(NestedTensor& input,
             return F::interpolate(input_tensor.unsqueeze(0), options).squeeze(0);
           },
           input_structure);
-        return NestedTensor(std::move(res));
+        return NestedTensor(std::move(res)).contiguous();
       } else {
         int size_i = 0;
         TensorNode res = map(
@@ -273,7 +273,7 @@ NestedTensor interpolate(NestedTensor& input,
               return F::interpolate(input_tensor.unsqueeze(0), options).squeeze(0);
             },
             input_structure);
-        return NestedTensor(std::move(res));
+        return NestedTensor(std::move(res)).contiguous();
       }
     }
 

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.0.1.dev202052023+2de5c5f'
-git_version = '2de5c5fb95e5fdc06d1d38ba14bf47d2d31c8f7e'
+__version__ = '0.0.1.dev202052621+174be9e'
+git_version = '174be9e656ecb9921461b92fb438856b3488a5ab'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION


### PR DESCRIPTION
Updated the logic of functions to always return contiguous results.
Added unit tests for each function.

PLEASE NOTE, this diff decreases the performance (CPU) 
Tested via segmentation pipeline: 
eval:  124.6   --> 129.39
total: 148.48 --> 153.11

Per func: 
conv2d +2s
relu -0.2s
batch_norm +2.3s
interpolate +0.2s