### PR TITLE
Fix cuda mode in segmentation benchmarks

### DIFF
--- a/benchmarks/segmentation_layers.py
+++ b/benchmarks/segmentation_layers.py
@@ -310,7 +310,6 @@ class SegLayersBenchMark(object):
             self.inputs, self.targets = self.get_input(cuda, n, c, h, w, h_var, w_var, seed)
 
             benchmarks = [(layer, self.get_benchmark(c, layer, cuda)) for layer in self.args.layers]
-            
             for layer, benchmark in benchmarks:
                 result = utils.benchmark_fn(benchmark, run_time=self.args.run_time, warmup=self.args.warmup)
                 result["#"] = str(i) + "/" + str(len(benchmarks) * len(params))


### PR DESCRIPTION
In case of running multiple layers on CUDA, we are hitting an error when layer is None

Tested via 
`clear && numactl --membind 0 --cpubind 0 taskset -c 0-11,24-35 python benchmarks/segmentation_layers.py -L  relu__tensor_iter relu__tensor_pad relu__nt relu_tensor_iter relu_tensor_pad relu_nt conv2d_iter_3x3 conv2d_pad_3x3 conv2d_nt_3x3 conv2d_iter_1x1 conv2d_pad_1x1 conv2d_nt_1x1 conv2d_iter_7x7 conv2d_pad_7x7 conv2d_nt_7x7 batch_norm_tensor_iter batch_norm_tensor_pad batch_norm_nt max_pool2d_tensor_iter max_pool2d_tensor_pad max_pool2d_nt dropout_tensor_iter dropout_tensor_pad dropout_nt interpolate_tensor_iter interpolate_tensor_pad interpolate_nt -N 3 -C 256 -H 80 -W 80 -V 0 10 20 -S 24 --run-time 25 --warmup 15 --cuda True  --csv-log all-1_25_15_cuda.txt`