### PR TITLE
Add support for sum.dim_IntList and mean.dim

### DIFF
--- a/nestedtensor/csrc/ReduceOps.cpp
+++ b/nestedtensor/csrc/ReduceOps.cpp
@@ -22,6 +22,34 @@ Tensor NestedTensor_cumsum(
       self));
 }
 
+#define REDUCE_DIM_LIST_FUNC(NAME, FUNC, MSG)                                 \
+  Tensor NestedTensor_##NAME(                                                 \
+      const Tensor& self,                                                     \
+      c10::ArrayRef<int64_t> dims,                                            \
+      bool keepdims,                                                          \
+      c10::optional<ScalarType> dtype) {                                      \
+    auto nt_impl = get_nested_tensor_impl(self);                              \
+    int64_t nested_dim = nt_impl->nested_dim();                               \
+    std::vector<int64_t> newdims;                                             \
+    for (auto dim : dims) {                                                   \
+      dim = maybe_wrap_dim(dim, nt_impl->dim());                              \
+      TORCH_CHECK(                                                            \
+          dim >= nested_dim,                                                  \
+          MSG " of nested dimensions is not implemented yet for dimension " + \
+              std::to_string(dim));                                           \
+      newdims.push_back(dim - nested_dim);                                    \
+    }                                                                         \
+    return wrap_tensor_node(map_nested_tensor(                                \
+        [nested_dim, newdims, keepdims](at::Tensor tensor) {                  \
+          return FUNC(tensor, c10::ArrayRef<int64_t>(newdims), keepdims);     \
+        },                                                                    \
+        self));                                                               \
+  }
+
+REDUCE_DIM_LIST_FUNC(mean_dim, at::mean, "mean");
+REDUCE_DIM_LIST_FUNC(sum_dim, at::sum, "sum");
+#undef REDUCE_DIM_LIST_FUNC
+
 Tensor NestedTensor_sum(const Tensor& self, c10::optional<ScalarType> dtype) {
   auto tensors = flatten(
       map([&dtype](at::Tensor tensor) { return at::sum(tensor, dtype); },
@@ -66,6 +94,8 @@ Tensor NestedTensor_prod(const Tensor& self, c10::optional<ScalarType> dtype) {
 
 TORCH_LIBRARY_IMPL(aten, PrivateUse1_PreAutograd, m) {
   m.impl_UNBOXED("cumsum", NestedTensor_cumsum);
+  m.impl_UNBOXED("sum.dim_IntList", NestedTensor_sum_dim);
+  m.impl_UNBOXED("mean.dim", NestedTensor_mean_dim);
   m.impl_UNBOXED("sum", NestedTensor_sum);
   m.impl_UNBOXED("mean", NestedTensor_mean);
   m.impl_UNBOXED("prod", NestedTensor_prod);

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.0.1.dev202081416+bafd896'
-git_version = 'bafd89620a11c3fdf7d561d415d1303786f5f2e4'
+__version__ = '0.0.1.dev202081413+9fbd9b3'
+git_version = '9fbd9b39ca120fdb03268c130938b96c63d222fd'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION


### PR DESCRIPTION
This doesn't support all the craziness like reducing the nested dimension by 1
when reducing at the nested dimension, and being able to reduce before the nested
dimension with lists if you reduce across the nested dimension.

It simply allows users to reduce across the nested dimension or higher.