### PR TITLE
Add dtype, device, requires_grad and pin_memory to constructor, disable NestedTensor.to

### DIFF
--- a/nestedtensor/csrc/ReduceOps.cpp
+++ b/nestedtensor/csrc/ReduceOps.cpp
@@ -15,7 +15,7 @@ Tensor NestedTensor_cumsum(
   dim = maybe_wrap_dim(dim, nt_impl->dim());
   TORCH_CHECK(
       dim >= nested_dim, "cumsum of nested dimensions is not implemented yet.");
-  return autograd_map_nested_tensor(
+  return map_nested_tensor(
       [nested_dim, dim](at::Tensor tensor) {
         return at::cumsum(tensor, dim - nested_dim);
       },

--- a/nestedtensor/csrc/ReduceOps.cpp
+++ b/nestedtensor/csrc/ReduceOps.cpp
@@ -15,7 +15,7 @@ Tensor NestedTensor_cumsum(
   dim = maybe_wrap_dim(dim, nt_impl->dim());
   TORCH_CHECK(
       dim >= nested_dim, "cumsum of nested dimensions is not implemented yet.");
-  return map_nested_tensor(
+  return autograd_map_nested_tensor(
       [nested_dim, dim](at::Tensor tensor) {
         return at::cumsum(tensor, dim - nested_dim);
       },

--- a/nestedtensor/csrc/creation.cpp
+++ b/nestedtensor/csrc/creation.cpp
@@ -4,7 +4,6 @@
 #include <nestedtensor/csrc/utils/nested_node.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
 #include <torch/extension.h>
-#include <torch/csrc/jit/python/pybind_utils.h>
 
 namespace py = pybind11;
 
@@ -26,7 +25,6 @@ NestedNode<py::object> py_to_nested_node(py::object&& py_obj) {
     return NestedNode<py::object>(std::move(py_obj));
   }
 }
-
 
 bool _verify_variables(
     const int64_t dim,
@@ -177,8 +175,10 @@ NestedNode<c10::IValue> py_to_nested_tensor(const py::object& py_obj) {
   if (THPVariable_Check(py_obj.ptr())) {
     at::Tensor tensor = THPVariable_Unpack(py_obj.ptr());
     if (is_nested_tensor_impl(tensor)) {
-      auto tensor_data_structure = get_nested_tensor_impl(tensor)->get_structure();
-      return map([](at::Tensor a) { return c10::IValue(a); }, tensor_data_structure);
+      auto tensor_data_structure =
+          get_nested_tensor_impl(tensor)->get_structure();
+      return map(
+          [](at::Tensor a) { return c10::IValue(a); }, tensor_data_structure);
     }
   }
   if (py::isinstance<py::sequence>(py_obj)) {
@@ -193,7 +193,14 @@ NestedNode<c10::IValue> py_to_nested_tensor(const py::object& py_obj) {
   }
 }
 
-NestedTensorImpl _as_nested_tensor(py::sequence list) {
+at::Tensor nested_tensor_impl(
+    py::sequence list,
+    py::object dtype_,
+    py::object device_,
+    bool requires_grad,
+    bool pin_memory) {
+  auto dtype = toTypeInferredIValue(dtype_).toScalarType();
+  auto device = toTypeInferredIValue(device_).toDevice();
   NestedNode<c10::IValue> ivalue_structure = py_to_nested_tensor(list);
   auto fn = [](c10::IValue a, bool result) { return result && a.isTensor(); };
   bool all_same =
@@ -201,18 +208,24 @@ NestedTensorImpl _as_nested_tensor(py::sequence list) {
   TORCH_CHECK(
       all_same,
       "Input nested list entries need to consist entirely of Tensors or NestedTensors.");
-  TensorNode structure =
-      map([](c10::IValue a) { return a.toTensor().clone().detach(); }, ivalue_structure);
+  TensorNode structure = map(
+      [&device, &dtype](c10::IValue a) {
+        return a.toTensor().clone().detach().to(device, dtype);
+      },
+      ivalue_structure);
   if (auto first = get_first_leaf(structure)) {
     if (!_verify_variables(*first, structure)) {
       _verify_variables(*first, structure, true);
     }
   }
-  return NestedTensorImpl(std::move(structure));
-}
-
-at::Tensor nested_tensor_impl(py::sequence list) {
-  return at::detail::make_tensor<NestedTensorImpl>(_as_nested_tensor(list)).contiguous();
+  auto result = at::detail::make_tensor<NestedTensorImpl>(std::move(structure)).contiguous();
+  if (requires_grad) {
+    result.requires_grad_();
+  }
+  if (pin_memory) {
+    result.pin_memory();
+  }
+  return result;
 }
 
 } // namespace nested_tensor

--- a/nestedtensor/csrc/creation.h
+++ b/nestedtensor/csrc/creation.h
@@ -7,7 +7,12 @@ namespace nested_tensor {
 
 NestedNode<py::object> py_to_nested_node(py::object&& py_obj);
 
-at::Tensor nested_tensor_impl(pybind11::sequence list);
+at::Tensor nested_tensor_impl(
+    pybind11::sequence list,
+    pybind11::object dtype,
+    pybind11::object device,
+    bool requires_grad,
+    bool pin_memory);
 
 } // namespace nested_tensor
 } // namespace torch

--- a/nestedtensor/nested/creation.py
+++ b/nestedtensor/nested/creation.py
@@ -14,15 +14,11 @@ def nested_tensor(data, dtype=None, device=None, requires_grad=False, pin_memory
         warnings.warn(
             "NestedTensor temporarily does not support autograd. Please use an older commit.")
 
-    result = nested.NestedTensor(_C.nested_tensor_impl(data))
-
-    if dtype is not None or device is not None:
-        result = result.to(dtype=dtype, device=device)
-    if requires_grad:
-        result = result.requires_grad_(requires_grad)
-    if pin_memory:
-        result = result.pin_memory()
-    return result
+    if dtype is None:
+        dtype = torch.get_default_dtype()
+    if device is None:
+        device = torch.device('cpu')
+    return nested.NestedTensor(_C.nested_tensor_impl(data, dtype, device, requires_grad, pin_memory))
 
 
 def as_nested_tensor(data, dtype=None, device=None, requires_grad=False, pin_memory=False):

--- a/nestedtensor/nested/nested.py
+++ b/nestedtensor/nested/nested.py
@@ -230,11 +230,7 @@ class NestedTensor(metaclass=NestedTensorMeta):
         return tuple(torch.ops.nestedtensor.sizes(self._impl))
 
     def to(self, *args, **kwargs):
-        # TODO: to is currently not supported by impls due to argparsing.
-        new_tensors = [t.to(*args, **kwargs) for t in self.unbind()]
-        # TODO: Make contiguous by default? Heavy operation...
-        # NOTE: Needs grad support, which nestedtensor.nested_tensor
-        # constructor doesn't have.
+        raise NotImplementedError("NestedTensor.to is currently not implemented.")
         return nestedtensor.as_nested_tensor(new_tensors)
 
     def __str__(self):

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.0.1.dev202082521+214d22e'
-git_version = '214d22ecc723656521b30e45d6307819cf1f41c7'
+__version__ = '0.0.1.dev20208260+33227d9'
+git_version = '33227d99aacb2f2d03896f0af1d7daa350270df4'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.0.1.dev20208260+33227d9'
-git_version = '33227d99aacb2f2d03896f0af1d7daa350270df4'
+__version__ = '0.0.1.dev20208261+fec69a4'
+git_version = 'fec69a40b45037ea4c3125a94c8925ec79fb77f8'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/test/test_nested_tensor_autograd.py
+++ b/test/test_nested_tensor_autograd.py
@@ -49,7 +49,7 @@ class TestNestedTensorAutograd(TestCase):
         def some_func(x):
             return torch.sum(x ** 2 + x ** 3)
 
-        nt1 = nestedtensor.as_nested_tensor([torch.tensor([1, 2, 3, 4]),
+        nt1 = nestedtensor.nested_tensor([torch.tensor([1, 2, 3, 4]),
                                              torch.tensor([1, 2, 3]),
                                              torch.tensor([1, 2])],
                                             dtype=torch.float) #, requires_grad=True)
@@ -62,7 +62,7 @@ class TestNestedTensorAutograd(TestCase):
         # self.assertEqual(nt1[1].grad, torch.tensor([ 5., 16., 33.]))
         # self.assertEqual(nt1[2].grad, torch.tensor([ 5., 16.]))
 
-        nt2 = nestedtensor.as_nested_tensor([torch.tensor([1, 2, 3, 4]),
+        nt2 = nestedtensor.nested_tensor([torch.tensor([1, 2, 3, 4]),
                                              torch.tensor([1, 2, 3]),
                                              torch.tensor([1, 2])],
                                             dtype=torch.float) # , requires_grad=True)

--- a/test/test_nested_tensor_class.py
+++ b/test/test_nested_tensor_class.py
@@ -82,9 +82,9 @@ class TestNestedTensor(TestCase):
 
         nested_tensor1 = nestedtensor.as_nested_tensor(nested_tensor)
         self.assertTrue(nested_tensor1 is nested_tensor)
-        nested_tensor2 = nestedtensor.as_nested_tensor(
-            nested_tensor, dtype=torch.int64)
-        self.assertTrue(nested_tensor2 is not nested_tensor)
+        self.assertRaises(NotImplementedError, lambda: nestedtensor.as_nested_tensor(
+            nested_tensor, dtype=torch.int64))
+        # self.assertTrue(nested_tensor2 is not nested_tensor)
 
     def test_constructor(self):
         for constructor in _iter_constructors():
@@ -284,14 +284,20 @@ class TestNestedTensor(TestCase):
 
             a1 = constructor([torch.tensor([1, 2]),
                               torch.tensor([2, 8])])
-            a2 = constructor([torch.tensor([0, 1]),
-                              torch.tensor([1, 0])], dtype=torch.bool)
-            a3 = constructor([torch.tensor([1, 0]),
-                              torch.tensor([0, 1])], dtype=torch.bool)
-            self.assertEqual((a1 == 2), a2)
-            self.assertEqual((a1 != 2), a3)
-            self.assertEqual((a1 == 2.0), a2)
-            self.assertEqual((a1 != 2.0), a3)
+            if constructor == nestedtensor.as_nested_tensor:
+                self.assertRaises(NotImplementedError, lambda: constructor([torch.tensor([0, 1]),
+                                                                            torch.tensor([1, 0])], dtype=torch.bool))
+                self.assertRaises(NotImplementedError, lambda: constructor([torch.tensor([1, 0]),
+                                                                            torch.tensor([0, 1])], dtype=torch.bool))
+            else:
+                a2 = constructor([torch.tensor([0, 1]),
+                                  torch.tensor([1, 0])], dtype=torch.bool)
+                a3 = constructor([torch.tensor([1, 0]),
+                                  torch.tensor([0, 1])], dtype=torch.bool)
+                self.assertEqual((a1 == 2), a2)
+                self.assertEqual((a1 != 2), a3)
+                self.assertEqual((a1 == 2.0), a2)
+                self.assertEqual((a1 != 2.0), a3)
 
     def test_dim(self):
         for constructor in _iter_constructors():
@@ -574,9 +580,9 @@ class TestNestedTensor(TestCase):
                    torch.randn(3, 8),
                    torch.randn(7, 8)]
         a1 = nestedtensor.nested_tensor(tensors)
-        a2 = a1.to(torch.int64)
-        for a, b in zip(tensors, a2.unbind()):
-            self.assertEqual(a.to(torch.int64), b)
+        self.assertRaises(NotImplementedError, lambda: a1.to(torch.int64))
+        # for a, b in zip(tensors, a2.unbind()):
+        #     self.assertEqual(a.to(torch.int64), b)
 
     def test_dtype(self):
         _test_property(self, lambda x: x.dtype)

--- a/test/test_nested_tensor_functional.py
+++ b/test/test_nested_tensor_functional.py
@@ -50,7 +50,7 @@ class TestFunctional(TestCase):
 
     def test_nn_embedding(self):
         inputs = [torch.randint(100, (L,)) for L in torch.randint(5, 50, (8,))]
-        x = nestedtensor.nested_tensor(inputs)
+        x = nestedtensor.nested_tensor(inputs, dtype=torch.int64)
         emb = torch.nn.Embedding(100, 8)
         y = emb(x)
         for i, inp in enumerate(inputs):
@@ -205,10 +205,10 @@ class TestFunctional(TestCase):
                 inputs[i].unsqueeze(0).contiguous(), targets[i].unsqueeze(0))
             tensor_res.append(t_res.squeeze(0))
 
-        for input_nt, target_nt in [(nestedtensor.nested_tensor(inputs), nestedtensor.nested_tensor(targets)),
-                                    (nestedtensor.as_nested_tensor(inputs), nestedtensor.as_nested_tensor(targets))]:
-            nt_res = torch.nn.functional.cross_entropy(input_nt, target_nt)
-            self.assertEqual(nestedtensor.nested_tensor(tensor_res), nt_res)
+        input_nt = nestedtensor.nested_tensor(inputs)
+        target_nt = nestedtensor.nested_tensor(targets, dtype=torch.int64)
+        nt_res = torch.nn.functional.cross_entropy(input_nt, target_nt)
+        self.assertEqual(nestedtensor.nested_tensor(tensor_res), nt_res)
 
     def test_nn_dropout(self):
         inputs = [

--- a/test/test_nested_tensor_nary.py
+++ b/test/test_nested_tensor_nary.py
@@ -29,8 +29,8 @@ def _gen_test_unary(func__, nested_dim, device):
         if func__ in ['mvlgamma']:
             data = utils.nested_map(lambda x: x.clamp(min=1), data)
 
-        a1 = nestedtensor.nested_tensor(data)
-        a3 = nestedtensor.nested_tensor(data)
+        a1 = nestedtensor.nested_tensor(data, device=device)
+        a3 = nestedtensor.nested_tensor(data, device=device)
         func_ = getattr(torch, func__)
         method_ = getattr(nestedtensor.NestedTensor, func__)
         method_inplace_ = getattr(nestedtensor.NestedTensor, func__ + "_")
@@ -88,7 +88,7 @@ def _gen_test_unary(func__, nested_dim, device):
             method = method_
             method_inplace = method_inplace_
 
-        a2 = nestedtensor.nested_tensor(utils.nested_map(func, data))
+        a2 = nestedtensor.nested_tensor(utils.nested_map(func, data), device=device)
 
         self.assertTrue(a1.nested_dim() == a2.nested_dim())
         self.assertTrue(a2.nested_dim() == a3.nested_dim())
@@ -183,9 +183,9 @@ for func__ in get_unary_functions():
     if func__ == 'fill':
         continue
     for nested_dim in range(1, 5):
-        avail_devices = ['cpu']
+        avail_devices = [torch.device('cpu')]
         if torch.cuda.is_available():
-            avail_devices += ['cuda']
+            avail_devices += [torch.device('cuda')]
         for device in avail_devices:
             setattr(TestUnary, "test_{0}_nested_dim_{1}_{2}".format(
                 func__, nested_dim, device), _gen_test_unary(func__, nested_dim, device))


### PR DESCRIPTION
to was implemented very inefficient and requires a lot of overloads. current usesites don't require ".to" other than for construction. we'll disable it for now until we need it again and then reimplement it as a native function.