### PR TITLE
Add static inference guard

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -35,11 +35,11 @@ else
 fi
 
 if [ "${CU_VERSION:-}" == cpu ] ; then
-    pip install https://download.pytorch.org/whl/nightly/cpu/torch-1.9.0.dev20210416%2Bcpu-${PYVSHORT}-linux_x86_64.whl
-    pip install https://download.pytorch.org/whl/nightly/cpu/torchvision-0.10.0.dev20210416%2Bcpu-${PYVSHORT}-linux_x86_64.whl
+    pip install https://download.pytorch.org/whl/nightly/cpu/torch-1.9.0.dev20210427%2Bcpu-${PYVSHORT}-linux_x86_64.whl
+    pip install https://download.pytorch.org/whl/nightly/cpu/torchvision-0.10.0.dev20210427%2Bcpu-${PYVSHORT}-linux_x86_64.whl
     USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 else
-    pip install https://download.pytorch.org/whl/nightly/cu102/torch-1.9.0.dev20210416%2Bcu102-${PYVSHORT}-linux_x86_64.whl
-    pip install https://download.pytorch.org/whl/nightly/cu102/torchvision-0.10.0.dev20210416-${PYVSHORT}-linux_x86_64.whl
+    pip install https://download.pytorch.org/whl/nightly/cu102/torch-1.9.0.dev20210427%2Bcu102-${PYVSHORT}-linux_x86_64.whl
+    pip install https://download.pytorch.org/whl/nightly/cu102/torchvision-0.10.0.dev20210427-${PYVSHORT}-linux_x86_64.whl
     USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 fi

--- a/nestedtensor/csrc/py_init.cpp
+++ b/nestedtensor/csrc/py_init.cpp
@@ -8,6 +8,8 @@
 #include <torch/extension.h>
 #include <chrono>
 
+static c10::InferenceMode guard;
+
 // NOTE: A NestedTensor without any constituents, i.e.
 // nested_tensor([]) is of dimension 1 because
 // tensor([]) is of dimension 1, but it is also

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.0.1+aded2ac'
-git_version = 'aded2acc0344d2115e35661614192dadcfa94fe6'
+__version__ = '0.0.1+f79ec60'
+git_version = 'f79ec60c02c783defbc0b3f586eefa721496fa07'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/test/test_nested_tensor_functional.py
+++ b/test/test_nested_tensor_functional.py
@@ -17,6 +17,7 @@ def _iter_constructors():
 
 
 def ntnt(x): return nestedtensor.nested_tensor(x, requires_grad=True)
+def ntnt_nograd(x): return nestedtensor.nested_tensor(x, requires_grad=False)
 
 
 class TestFunctional(TestCase):
@@ -48,7 +49,6 @@ class TestFunctional(TestCase):
         # nt_cont = relu(nt)
         # self.assertEqual(True, nt_cont.is_contiguous())
 
-    @unittest.skip("Requires autograd support")
     def test_nn_embedding(self):
         inputs = [torch.randint(100, (L,)) for L in torch.randint(5, 50, (8,))]
         x = nestedtensor.nested_tensor(inputs, dtype=torch.int64)
@@ -88,7 +88,6 @@ class TestFunctional(TestCase):
         run_test(lambda: torch.nn.EmbeddingBag(100, 8, sparse=True), [torch.randint(100, (L,)) for L in torch.randint(3, 7, (5,))])
 
 
-    @unittest.skip("Requires autograd support")
     def test_nn_functional_conv2d(self):
         tensor1 = torch.rand(3, 128, 128)
         tensor2 = torch.rand(3, 300, 400)
@@ -141,7 +140,6 @@ class TestFunctional(TestCase):
                 nt, running_mean, running_var)
             self.assertEqual(nestedtensor.nested_tensor(tensor_res), nt_res)
 
-    @unittest.skip("Requires autograd support")
     def test_nn_functional_max_pool2d(self):
         inputs = [
             torch.randn(3, 500, 600),
@@ -196,7 +194,6 @@ class TestFunctional(TestCase):
             nt_res = torch.nn.functional.relu(nt)
             self.assertEqual(nestedtensor.nested_tensor(tensor_res), nt_res)
 
-    @unittest.skip("Requires autograd support")
     def test_nn_functional_cross_entropy(self):
         inputs = [
             torch.randn(3, 300, 300),
@@ -219,7 +216,6 @@ class TestFunctional(TestCase):
         nt_res = torch.nn.functional.cross_entropy(input_nt, target_nt)
         self.assertEqual(nestedtensor.nested_tensor(tensor_res), nt_res)
 
-    @unittest.skip("Requires autograd support")
     def test_nn_dropout(self):
         inputs = [
             torch.randn(3, 128, 128),
@@ -237,7 +233,6 @@ class TestFunctional(TestCase):
             self.assertEqual(nestedtensor.nested_tensor(
                 tensor_res).size(), nt_res.size())
 
-    @unittest.skip("Requires autograd support")
     def test_nn_functional_dropout(self):
         inputs = [
             torch.randn(3, 128, 128),
@@ -250,11 +245,10 @@ class TestFunctional(TestCase):
                 inputs[i].unsqueeze(0).contiguous())
             tensor_res.append(t_res.squeeze(0))
 
-        nt = ntnt(inputs)
+        nt = ntnt_nograd(inputs)
         nt_res = torch.nn.functional.dropout(nt)
-        self.assertEqual(ntnt(tensor_res).size(), nt_res.size())
+        self.assertEqual(ntnt_nograd(tensor_res).size(), nt_res.size())
 
-    @unittest.skip("Requires autograd support")
     def test_nn_functional_interpolate(self):
         inputs = [
             torch.randn(3, 200, 300),
@@ -378,7 +372,6 @@ class TestFunctional(TestCase):
                 3), constructor([t.reshape(2, 3, 1)]))
             self.assertRaises(IndexError, lambda: nt.unsqueeze(4))
 
-    @unittest.skip("Requires autograd support")
     def test_matmul(self):
         for constructor in _iter_constructors():
             t1 = torch.randn(2, 3)
@@ -397,7 +390,6 @@ class TestFunctional(TestCase):
             self.assertEqual(result2[1][0], torch.matmul(t22, t1))
             self.assertEqual(result2[1][1], torch.matmul(t21, t1))
 
-    @unittest.skip("Requires autograd support")
     def test_transpose(self):
         t0 = torch.randn(3, 3, 4)
         t1 = torch.randn(2, 4, 3)
@@ -419,7 +411,6 @@ class TestFunctional(TestCase):
             list(map(lambda x: x.unbind(), t_t.unbind())))
         self.assertEqual(t_t, nt_t.to_tensor())
 
-    @unittest.skip("Requires autograd support")
     def test_flatten(self):
         t0 = torch.randn(3, 3, 4)
         t1 = torch.randn(2, 4, 3)
@@ -451,7 +442,6 @@ class TestFunctional(TestCase):
         map(self.assertEqual, zip(ts[0].unbind(), ts_r[0].unbind()))
         map(self.assertEqual, zip(ts[1].unbind(), ts_r[1].unbind()))
 
-    @unittest.skip("Requires autograd support")
     def test_reshape(self):
 
         t0 = torch.randn(3, 3)
@@ -507,35 +497,31 @@ class TestFunctional(TestCase):
         for i in range(nt.dim() - nt.nested_dim()):
             _map_fn(i, fn(nt, i + nt.nested_dim()))
 
-    @unittest.skip("Requires autograd support")
     def test_softmax_1(self):
         ts = [[], []]
-        nt = ntnt(ts)
+        nt = ntnt_nograd(ts)
         self._test_softmax(ts, nt)
 
-    @unittest.skip("Requires autograd support")
     def test_softmax_2(self):
         t0 = torch.randn(3)
         t1 = torch.randn(2)
         t2 = torch.randn(3)
         ts = [[t0, t1], [t2]]
-        nt = ntnt(ts)
+        nt = ntnt_nograd(ts)
         self._test_softmax(ts, nt)
 
-    @unittest.skip("Requires autograd support")
     def test_softmax_3(self):
         t0 = torch.randn(3, 2, 1)
         t1 = torch.randn(2, 3, 1)
         t2 = torch.randn(3, 1, 2)
         ts = [[t0, t1], [t2]]
-        nt = ntnt(ts)
+        nt = ntnt_nograd(ts)
         self._test_softmax(ts, nt)
 
-    @unittest.skip("Requires autograd support")
     def test_softmax_4(self):
         ts = torch.randn(6, 4, 3, 2, 5)
         ts = list(map(lambda x: x.unbind(), ts.unbind()))
-        nt = ntnt(ts)
+        nt = ntnt_nograd(ts)
         self._test_softmax(ts, nt)
 
 


### PR DESCRIPTION
This guard will disable autograd for anyone who is even just importing nestedtensor. It's a temporary hack until the inferencemode python guard becomes available.