### PR TITLE
Restrict nested dim to one - tests and constructor

### DIFF
--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+dc7f190'
-git_version = 'dc7f1901bf38597385c4c2915088d3e8437d4781'
+__version__ = '0.1.4+37cd5db'
+git_version = '37cd5db5161446e66cd3c2eb5fc1e4299b57b11a'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/test/test_nested_tensor_class.py
+++ b/test/test_nested_tensor_class.py
@@ -23,7 +23,8 @@ def _iter_constructors():
 
 def _test_property(self, fn):
     for constructor in _iter_constructors():
-        num_nested_tensor = 3
+        # TODO: Used to be 3. Currently only supporting nested dim 1.
+        num_nested_tensor = 1
         nested_tensor_lists = [utils.gen_nested_list(i, i, 3)
                                for i in range(1, num_nested_tensor)]
         first_tensors = [utils.get_first_tensor(
@@ -37,7 +38,8 @@ class TestNestedTensor(TestCase):
 
     def test_nested_constructor(self):
         for constructor in _iter_constructors():
-            num_nested_tensor = 3
+            # TODO: Currently only supporting nested dim 1
+            num_nested_tensor = 1
             # TODO: Shouldn't be constructable
             [utils.gen_nested_tensor(i, i, 3, constructor=constructor)
              for i in range(1, num_nested_tensor)]
@@ -160,6 +162,9 @@ class TestNestedTensor(TestCase):
             str(a)
             repr(a)
 
+    @unittest.skip("Currently only supporting nested dim 1.")
+    def test_repr_string_nested(self):
+        for constructor in _iter_constructors():
             a = constructor(
                 [
                     [torch.tensor([[1, 2], [2, 3]]), torch.tensor([[3, 4]])],
@@ -225,6 +230,9 @@ class TestNestedTensor(TestCase):
             self.assertEqual(b[0][0], 1)
             self.assertEqual(b[0][1], 2)
 
+    @unittest.skip("Currently only supporting nested dim 1.")
+    def test_nested_size_nested(self):
+        for constructor in _iter_constructors():
             a = constructor(
                 [[torch.randn(1)], [torch.randn(2), torch.randn(1)]])
             self.assertEqual(a.nested_size()[0][0], torch.Size([1]))
@@ -307,12 +315,17 @@ class TestNestedTensor(TestCase):
             self.assertEqual(a1.dim(), 1)
             a1 = constructor([torch.tensor([1, 2, 3, 4])])
             self.assertEqual(a1.dim(), 2)
+
+    @unittest.skip("Currently only supporting nested dim 1.")
+    def test_dim_nested(self):
+        for constructor in _iter_constructors():
             a1 = constructor([
                 [torch.tensor([1, 2, 3, 4])],
                 [torch.tensor([5, 6, 7, 8]), torch.tensor([9, 0, 0, 0])]
             ])
             self.assertEqual(a1.dim(), 3)
 
+    @unittest.skip("Currently only supporting nested dim 1.")
     def test_nested_dim(self):
         for constructor in _iter_constructors():
             nt = constructor([torch.tensor(3)])
@@ -341,14 +354,15 @@ class TestNestedTensor(TestCase):
                 self.assertTrue(a is not a1)
                 self.assertTrue(b is not b1)
 
-                nt1 = nestedtensor.nested_tensor([[c, d], [e]])
-                nt11, nt12 = unbind_fn(nt1, 0)
-                c1, d1 = unbind_fn(nt11, 0)
-                e1 = unbind_fn(nt12, 0)[0]
+                # Currently only supporting nested dim 1
+                # nt1 = nestedtensor.nested_tensor([[c, d], [e]])
+                # nt11, nt12 = unbind_fn(nt1, 0)
+                # c1, d1 = unbind_fn(nt11, 0)
+                # e1 = unbind_fn(nt12, 0)[0]
 
-                self.assertTrue(c is not c1)
-                self.assertTrue(d is not d1)
-                self.assertTrue(e is not e1)
+                # self.assertTrue(c is not c1)
+                # self.assertTrue(d is not d1)
+                # self.assertTrue(e is not e1)
 
                 nt = nestedtensor.nested_tensor([a, b])
                 a1, b1 = unbind_fn(nt, 0)
@@ -379,6 +393,7 @@ class TestNestedTensor(TestCase):
                   torch.tensor([]),
                   torch.tensor([]),
                   torch.tensor([]))
+
         _test_fn(lambda x, dim: x.unbind(dim))
         _test_fn(lambda x, dim: torch.unbind(x, dim))
 
@@ -422,17 +437,18 @@ class TestNestedTensor(TestCase):
             # TODO: Add more tensors and unbind across more dimensions to create mixing
 
             c = torch.rand(4, 3)
-            nt = nestedtensor.nested_tensor([[a], [b, c]])
-            nt_a, nt_b = unbind_fn(nt, 0)
-            self.assertEqual(nt_a, nestedtensor.nested_tensor(
-                [a]), ignore_contiguity=True)
-            self.assertEqual(nt_b, nestedtensor.nested_tensor(
-                [b, c]), ignore_contiguity=True)
-            result = (
-                nestedtensor.nested_tensor([a, b]),
-                nestedtensor.nested_tensor([c]))
-            for x, y in zip(unbind_fn(nt, 1), result):
-                self.assertEqual(x, y, ignore_contiguity=True)
+            # TODO: Currently only supporting nested dim 1
+            # nt = nestedtensor.nested_tensor([[a], [b, c]])
+            # nt_a, nt_b = unbind_fn(nt, 0)
+            # self.assertEqual(nt_a, nestedtensor.nested_tensor(
+            #     [a]), ignore_contiguity=True)
+            # self.assertEqual(nt_b, nestedtensor.nested_tensor(
+            #     [b, c]), ignore_contiguity=True)
+            # result = (
+            #     nestedtensor.nested_tensor([a, b]),
+            #     nestedtensor.nested_tensor([c]))
+            # for x, y in zip(unbind_fn(nt, 1), result):
+            #     self.assertEqual(x, y, ignore_contiguity=True)
         _test_fn(lambda x, dim: x.unbind(dim))
         _test_fn(lambda x, dim: torch.unbind(x, dim))
 
@@ -447,10 +463,11 @@ class TestNestedTensor(TestCase):
             a = constructor([torch.tensor(1), torch.tensor(2)])
             self.assertEqual(a.size(), (2,))
 
-            a = constructor([[torch.rand(1, 8),
-                              torch.rand(3, 8)],
-                             [torch.rand(7, 8)]])
-            self.assertEqual(a.size(), (2, None, None, 8))
+            # TODO: Currently only supporting nested dim 1
+            # a = constructor([[torch.rand(1, 8),
+            #                   torch.rand(3, 8)],
+            #                  [torch.rand(7, 8)]])
+            # self.assertEqual(a.size(), (2, None, None, 8))
 
             a = constructor([torch.rand(1, 2),
                              torch.rand(1, 8)])
@@ -472,55 +489,67 @@ class TestNestedTensor(TestCase):
             self.assertRaises(IndexError, lambda: a.to_tensor(1))
             self.assertRaises(IndexError, lambda: a.to_tensor(2))
 
-            t_a = torch.randn(2, 3)
-            t_b = torch.randn(2, 3)
-            a = constructor([[t_a, t_b]])
-            result = torch.stack([torch.stack([t_a, t_b])])
-            self.assertEqual(a.to_tensor(), result)
-            self.assertEqual(a.to_tensor(0), result)
+            # Currently only supporting nested dime 1.
+            # t_a = torch.randn(2, 3)
+            # t_b = torch.randn(2, 3)
+            # a = constructor([[t_a, t_b]])
+            # result = torch.stack([torch.stack([t_a, t_b])])
+            # self.assertEqual(a.to_tensor(), result)
+            # self.assertEqual(a.to_tensor(0), result)
+
+            # nested dim 1 change: Was already commented out
             # self.assertEqual(a.to_tensor(1), nestedtensor.as_nested_tensor(
             #     [torch.stack([t_a, t_b])]))
             # self.assertEqual(a.to_tensor(
             #     2), nestedtensor.as_nested_tensor([[t_a, t_b]]))
             # self.assertEqual(a.to_tensor(
             #     3), nestedtensor.as_nested_tensor([[t_a, t_b]]))
-            self.assertRaises(RuntimeError, lambda: a.to_tensor(1))
-            self.assertRaises(RuntimeError, lambda: a.to_tensor(2))
-            self.assertRaises(RuntimeError, lambda: a.to_tensor(3))
-            self.assertRaises(IndexError, lambda: a.to_tensor(4))
 
-            t_c = torch.randn(2, 3)
-            t_d = torch.randn(2, 3)
-            a = constructor([[t_a, t_b], [t_c, t_d]])
-            result = torch.stack(
-                [torch.stack([t_a, t_b]), torch.stack([t_c, t_d])])
-            self.assertEqual(a.to_tensor(), result)
-            self.assertEqual(a.to_tensor(0), result)
+            # self.assertRaises(RuntimeError, lambda: a.to_tensor(1))
+            # self.assertRaises(RuntimeError, lambda: a.to_tensor(2))
+            # self.assertRaises(RuntimeError, lambda: a.to_tensor(3))
+            # self.assertRaises(IndexError, lambda: a.to_tensor(4))
+
+            # Currently only supporting nested dime 1.
+            # t_c = torch.randn(2, 3)
+            # t_d = torch.randn(2, 3)
+            # a = constructor([[t_a, t_b], [t_c, t_d]])
+            # result = torch.stack(
+            #     [torch.stack([t_a, t_b]), torch.stack([t_c, t_d])])
+            # self.assertEqual(a.to_tensor(), result)
+            # self.assertEqual(a.to_tensor(0), result)
+
+            # nested dim 1 change: Was already commented out
             # self.assertEqual(a.to_tensor(1), nestedtensor.as_nested_tensor(
             #     [torch.stack([t_a, t_b]), torch.stack([t_c, t_d])]))
             # self.assertEqual(a.to_tensor(2), nestedtensor.as_nested_tensor(
             #     [[t_a, t_b], [t_c, t_d]]))
             # self.assertEqual(a.to_tensor(3), nestedtensor.as_nested_tensor(
             #     [[t_a, t_b], [t_c, t_d]]))
-            self.assertRaises(RuntimeError, lambda: a.to_tensor(1))
-            self.assertRaises(RuntimeError, lambda: a.to_tensor(2))
-            self.assertRaises(RuntimeError, lambda: a.to_tensor(3))
-            self.assertRaises(IndexError, lambda: a.to_tensor(4))
 
-            t_e = torch.randn(3, 2)
-            t_f = torch.randn(3, 2)
-            a = constructor([[t_a, t_b], [t_e, t_f]])
-            self.assertRaises(IndexError, lambda: a.to_tensor(0))
+            # self.assertRaises(RuntimeError, lambda: a.to_tensor(1))
+            # self.assertRaises(RuntimeError, lambda: a.to_tensor(2))
+            # self.assertRaises(RuntimeError, lambda: a.to_tensor(3))
+            # self.assertRaises(IndexError, lambda: a.to_tensor(4))
+
+            # Currently only supporting nested dime 1.
+            # t_e = torch.randn(3, 2)
+            # t_f = torch.randn(3, 2)
+            # a = constructor([[t_a, t_b], [t_e, t_f]])
+            # self.assertRaises(IndexError, lambda: a.to_tensor(0))
+
+            # nested dim 1 change: Was already commented out
             # self.assertEqual(a.to_tensor(1), nestedtensor.as_nested_tensor(
             #     [torch.stack([t_a, t_b]), torch.stack([t_e, t_f])]))
             # self.assertEqual(a.to_tensor(2), nestedtensor.as_nested_tensor(
             #     [[t_a, t_b], [t_e, t_f]]))
             # self.assertEqual(a.to_tensor(3), nestedtensor.as_nested_tensor(
             #     [[t_a, t_b], [t_e, t_f]]))
-            self.assertRaises(RuntimeError, lambda: a.to_tensor(1))
-            self.assertRaises(RuntimeError, lambda: a.to_tensor(2))
-            self.assertRaises(RuntimeError, lambda: a.to_tensor(3))
-            self.assertRaises(IndexError, lambda: a.to_tensor(4))
+
+            # self.assertRaises(RuntimeError, lambda: a.to_tensor(1))
+            # self.assertRaises(RuntimeError, lambda: a.to_tensor(2))
+            # self.assertRaises(RuntimeError, lambda: a.to_tensor(3))
+            # self.assertRaises(IndexError, lambda: a.to_tensor(4))
 
     def test_to_nested_tensor(self):
         for constructor in _iter_constructors():
@@ -546,50 +575,53 @@ class TestNestedTensor(TestCase):
             result = constructor([t_a, t_b])
             self.assertEqual(a.to_nested_tensor(), result)
             self.assertEqual(a.to_nested_tensor(0), result)
-            result = constructor([t_a.unbind(0), t_b.unbind(0)])
-            self.assertEqual(a.to_nested_tensor(1), result)
-            result = constructor(
-                [list(map(lambda x: x.unbind(), t_a.unbind())),
-                 list(map(lambda x: x.unbind(), t_b.unbind()))]
-            )
-            self.assertEqual(a.to_nested_tensor(2), result)
-            self.assertRaises(IndexError, lambda: a.to_nested_tensor(3))
 
-            a = constructor([[t_a, t_b]])
-            result = constructor([[t_a, t_b]])
-            self.assertEqual(a.to_nested_tensor(), result)
-            self.assertEqual(a.to_nested_tensor(0), result)
-            self.assertEqual(a.to_nested_tensor(1), result)
-            result = constructor([[t_a.unbind(0), t_b.unbind(0)]])
-            self.assertEqual(a.to_nested_tensor(2), result)
-            result = constructor([[list(map(lambda x: x.unbind(), t_a.unbind())),
-                                   list(map(lambda x: x.unbind(), t_b.unbind()))]])
-            self.assertEqual(a.to_nested_tensor(3), result)
-            self.assertRaises(IndexError, lambda: a.to_nested_tensor(4))
+            # Currently only supporting nested dime 1.
+            # result = constructor([t_a.unbind(0), t_b.unbind(0)])
+            # self.assertEqual(a.to_nested_tensor(1), result)
+            # result = constructor(
+            #     [list(map(lambda x: x.unbind(), t_a.unbind())),
+            #      list(map(lambda x: x.unbind(), t_b.unbind()))]
+            # )
+            # self.assertEqual(a.to_nested_tensor(2), result)
+            # self.assertRaises(IndexError, lambda: a.to_nested_tensor(3))
 
-            t_c = torch.randn(2, 4)
-            a = constructor([[t_a, t_b], [t_c]])
-            result = constructor([[t_a, t_b], [t_c]])
-            self.assertEqual(a.to_nested_tensor(), result)
-            self.assertEqual(a.to_nested_tensor(0), result)
-            self.assertEqual(a.to_nested_tensor(1), result)
-            result = constructor(
-                [[t_a.unbind(), t_b.unbind()], [t_c.unbind()]])
-            self.assertEqual(a.to_nested_tensor(2), result)
-            result = constructor([[list(map(lambda x: x.unbind(), t_a.unbind())),
-                                   list(map(lambda x: x.unbind(), t_b.unbind()))],
-                                  [list(map(lambda x: x.unbind(), t_c.unbind()))]])
-            self.assertEqual(a.to_nested_tensor(3), result)
-            self.assertRaises(IndexError, lambda: a.to_nested_tensor(4))
+            # Currently only supporting nested dime 1.
+            # a = constructor([[t_a, t_b]])
+            # result = constructor([[t_a, t_b]])
+            # self.assertEqual(a.to_nested_tensor(), result)
+            # self.assertEqual(a.to_nested_tensor(0), result)
+            # self.assertEqual(a.to_nested_tensor(1), result)
+            # result = constructor([[t_a.unbind(0), t_b.unbind(0)]])
+            # self.assertEqual(a.to_nested_tensor(2), result)
+            # result = constructor([[list(map(lambda x: x.unbind(), t_a.unbind())),
+            #                        list(map(lambda x: x.unbind(), t_b.unbind()))]])
+            # self.assertEqual(a.to_nested_tensor(3), result)
+            # self.assertRaises(IndexError, lambda: a.to_nested_tensor(4))
 
-            t = torch.randn(2, 3)
-            self.assertEqual(t, nestedtensor.to_nested_tensor(t, 0))
-            self.assertEqual(ntnt_nograd(t.unbind()),
-                             nestedtensor.to_nested_tensor(t, 1))
-            self.assertEqual(ntnt_nograd(
-                [ti.unbind() for ti in t.unbind()]), nestedtensor.to_nested_tensor(t, 2))
-            self.assertRaises(
-                IndexError, lambda: nestedtensor.to_nested_tensor(t, 3))
+            # t_c = torch.randn(2, 4)
+            # a = constructor([[t_a, t_b], [t_c]])
+            # result = constructor([[t_a, t_b], [t_c]])
+            # self.assertEqual(a.to_nested_tensor(), result)
+            # self.assertEqual(a.to_nested_tensor(0), result)
+            # self.assertEqual(a.to_nested_tensor(1), result)
+            # result = constructor(
+            #     [[t_a.unbind(), t_b.unbind()], [t_c.unbind()]])
+            # self.assertEqual(a.to_nested_tensor(2), result)
+            # result = constructor([[list(map(lambda x: x.unbind(), t_a.unbind())),
+            #                        list(map(lambda x: x.unbind(), t_b.unbind()))],
+            #                       [list(map(lambda x: x.unbind(), t_c.unbind()))]])
+            # self.assertEqual(a.to_nested_tensor(3), result)
+            # self.assertRaises(IndexError, lambda: a.to_nested_tensor(4))
+
+            # t = torch.randn(2, 3)
+            # self.assertEqual(t, nestedtensor.to_nested_tensor(t, 0))
+            # self.assertEqual(ntnt_nograd(t.unbind()),
+            #                  nestedtensor.to_nested_tensor(t, 1))
+            # self.assertEqual(ntnt_nograd(
+            #     [ti.unbind() for ti in t.unbind()]), nestedtensor.to_nested_tensor(t, 2))
+            # self.assertRaises(
+            #     IndexError, lambda: nestedtensor.to_nested_tensor(t, 3))
 
     def test_to(self):
         tensors = [torch.randn(1, 8),
@@ -649,6 +681,7 @@ class TestNestedTensor(TestCase):
         self.assertFalse(a5.is_pinned())
         self.assertFalse(a6.is_pinned())
 
+    @unittest.skip("Currently only supporting nested dim 1.")
     def test_getitem(self):
         a, b, c = torch.randn(3, 4), torch.randn(4, 3), torch.randn(1, 3)
         nt = ntnt_nograd([[a, b], [c]])
@@ -700,8 +733,9 @@ class TestNestedTensor(TestCase):
 
         nt0 = ntnt_nograd([a, b])
         nt1 = ntnt_nograd([c])
-        self.assertEqual(torch.stack(
-            [nt0, nt1], dim=0), ntnt_nograd([[a, b], [c]]))
+        # Currently only supporting nested dime 1.
+        # self.assertEqual(torch.stack(
+        #     [nt0, nt1], dim=0), ntnt_nograd([[a, b], [c]]))
         self.assertEqual(torch.stack(
             [nt0, nt1], dim=1),
             ntnt_nograd([torch.stack([a, c]), b.reshape(1, 3, 4)]))
@@ -757,7 +791,9 @@ class TestNestedTensor(TestCase):
 
 
 class TestContiguous(TestCase):
-    def test_contiguous(self):
+
+    @unittest.skip("Nested dim currently restricted to 1.")
+    def test_contiguous_nested(self):
         for _ in range(1, 10):
             # data = gen_nested_list(1, 2, 3, size_low=1, size_high=3)
             data = [[torch.rand(1, 2), torch.rand(3, 4)], [torch.rand(5, 6)]]
@@ -769,6 +805,7 @@ class TestContiguous(TestCase):
         nt.cos_()
         nt.cos()
 
+    def test_contiguous(self):
         a = nestedtensor.as_nested_tensor([torch.tensor([1, 2]),
                                            torch.tensor([3, 4]),
                                            torch.tensor([5, 6]),

--- a/test/test_nested_tensor_functional.py
+++ b/test/test_nested_tensor_functional.py
@@ -339,42 +339,46 @@ class TestFunctional(TestCase):
             nt1.copy_(nt2)
             self.assertEqual(nt1, nt2)
 
-            nt1 = constructor(
-                [[torch.randn(1, 2, 3), torch.randn(2, 1, 3)], [torch.randn(3, 2, 1)]])
-            nt2 = constructor(
-                [[torch.randn(1, 2, 3), torch.randn(2, 1, 3)], [torch.randn(3, 2, 1)]])
-            nt1.copy_(nt2)
-            self.assertEqual(nt1, nt2)
+            # Currently only supporting nested dim 1.
+            # nt1 = constructor(
+            #     [[torch.randn(1, 2, 3), torch.randn(2, 1, 3)], [torch.randn(3, 2, 1)]])
+            # nt2 = constructor(
+            #     [[torch.randn(1, 2, 3), torch.randn(2, 1, 3)], [torch.randn(3, 2, 1)]])
+            # nt1.copy_(nt2)
+            # self.assertEqual(nt1, nt2)
 
+    @unittest.skip("Currently only supporting nested dim 1.")
     def test_unsqueeze(self):
         for constructor in _iter_constructors():
             t = torch.randn(2, 3)
 
-            nt = constructor([[t.reshape(2, 3)]])
-            self.assertEqual(nt.unsqueeze(
-                0), constructor([[[t.reshape(2, 3)]]]))
-            self.assertEqual(nt.unsqueeze(
-                1), constructor([[[t.reshape(2, 3)]]]))
-            self.assertEqual(nt.unsqueeze(
-                2), constructor([[t.reshape(1, 2, 3)]]))
-            self.assertEqual(nt.unsqueeze(
-                3), constructor([[t.reshape(2, 1, 3)]]))
-            self.assertEqual(nt.unsqueeze(
-                4), constructor([[t.reshape(2, 3, 1)]]))
+            # Currently only supporting nested dim 1.
+            # nt = constructor([[t.reshape(2, 3)]])
+            # self.assertEqual(nt.unsqueeze(
+            #     0), constructor([[[t.reshape(2, 3)]]]))
+            # self.assertEqual(nt.unsqueeze(
+            #     1), constructor([[[t.reshape(2, 3)]]]))
+            # self.assertEqual(nt.unsqueeze(
+            #     2), constructor([[t.reshape(1, 2, 3)]]))
+            # self.assertEqual(nt.unsqueeze(
+            #     3), constructor([[t.reshape(2, 1, 3)]]))
+            # self.assertEqual(nt.unsqueeze(
+            #     4), constructor([[t.reshape(2, 3, 1)]]))
 
-            t0 = t.reshape(3, 2)
-            t1 = t
-            t2 = torch.randn(4, 5)
-            nt = constructor([[t0, t1], [t2]])
-            self.assertEqual(nt.unsqueeze(0), constructor([[[t0, t1], [t2]]]))
-            self.assertEqual(nt.unsqueeze(
-                1), constructor([[[t0, t1]], [[t2]]]))
-            self.assertEqual(nt.unsqueeze(2), constructor(
-                [[t0.reshape(1, 3, 2), t1.reshape(1, 2, 3)], [t2.reshape(1, 4, 5)]]))
-            self.assertEqual(nt.unsqueeze(3), constructor(
-                [[t0.reshape(3, 1, 2), t1.reshape(2, 1, 3)], [t2.reshape(4, 1, 5)]]))
-            self.assertEqual(nt.unsqueeze(4), constructor(
-                [[t0.reshape(3, 2, 1), t1.reshape(2, 3, 1)], [t2.reshape(4, 5, 1)]]))
+            # Currently only supporting nested dim 1.
+            # t0 = t.reshape(3, 2)
+            # t1 = t
+            # t2 = torch.randn(4, 5)
+            # nt = constructor([[t0, t1], [t2]])
+            # self.assertEqual(nt.unsqueeze(0), constructor([[[t0, t1], [t2]]]))
+            # self.assertEqual(nt.unsqueeze(
+            #     1), constructor([[[t0, t1]], [[t2]]]))
+            # self.assertEqual(nt.unsqueeze(2), constructor(
+            #     [[t0.reshape(1, 3, 2), t1.reshape(1, 2, 3)], [t2.reshape(1, 4, 5)]]))
+            # self.assertEqual(nt.unsqueeze(3), constructor(
+            #     [[t0.reshape(3, 1, 2), t1.reshape(2, 1, 3)], [t2.reshape(4, 1, 5)]]))
+            # self.assertEqual(nt.unsqueeze(4), constructor(
+            #     [[t0.reshape(3, 2, 1), t1.reshape(2, 3, 1)], [t2.reshape(4, 5, 1)]]))
 
             t = torch.randn(2, 3)
             nt = constructor([t])
@@ -399,13 +403,15 @@ class TestFunctional(TestCase):
             result1 = torch.matmul(a, t22)
             self.assertEqual(result[1], result1[0])
             self.assertEqual(result[1], result1[1])
-            c = constructor([[t21, t22], [t22, t21]])
-            result2 = torch.matmul(c, t1)
-            self.assertEqual(result2[0][0], torch.matmul(t21, t1))
-            self.assertEqual(result2[0][1], torch.matmul(t22, t1))
-            self.assertEqual(result2[1][0], torch.matmul(t22, t1))
-            self.assertEqual(result2[1][1], torch.matmul(t21, t1))
+            # Currently only supporting nested dim 1.
+            # c = constructor([[t21, t22], [t22, t21]])
+            # result2 = torch.matmul(c, t1)
+            # self.assertEqual(result2[0][0], torch.matmul(t21, t1))
+            # self.assertEqual(result2[0][1], torch.matmul(t22, t1))
+            # self.assertEqual(result2[1][0], torch.matmul(t22, t1))
+            # self.assertEqual(result2[1][1], torch.matmul(t21, t1))
 
+    @unittest.skip("Currently only supporting nested dim 1.")
     def test_transpose(self):
         t0 = torch.randn(3, 3, 4)
         t1 = torch.randn(2, 4, 3)
@@ -427,6 +433,7 @@ class TestFunctional(TestCase):
             list(map(lambda x: x.unbind(), t_t.unbind())))
         self.assertEqual(t_t, nt_t.to_tensor())
 
+    @unittest.skip("Currently only supporting nested dim 1.")
     def test_flatten(self):
         t0 = torch.randn(3, 3, 4)
         t1 = torch.randn(2, 4, 3)
@@ -458,8 +465,8 @@ class TestFunctional(TestCase):
         map(self.assertEqual, zip(ts[0].unbind(), ts_r[0].unbind()))
         map(self.assertEqual, zip(ts[1].unbind(), ts_r[1].unbind()))
 
+    @unittest.skip("Currently only supporting nested dim 1.")
     def test_reshape(self):
-
         t0 = torch.randn(3, 3)
         t1 = torch.randn(2, 3)
         t2 = torch.randn(3, 3)
@@ -513,11 +520,13 @@ class TestFunctional(TestCase):
         for i in range(nt.dim() - nt.nested_dim()):
             _map_fn(i, fn(nt, i + nt.nested_dim()))
 
+    @unittest.skip("Currently only supporting nested dim 1.")
     def test_softmax_1(self):
         ts = [[], []]
         nt = ntnt_nograd(ts)
         self._test_softmax(ts, nt)
 
+    @unittest.skip("Currently only supporting nested dim 1.")
     def test_softmax_2(self):
         t0 = torch.randn(3)
         t1 = torch.randn(2)
@@ -526,6 +535,7 @@ class TestFunctional(TestCase):
         nt = ntnt_nograd(ts)
         self._test_softmax(ts, nt)
 
+    @unittest.skip("Currently only supporting nested dim 1.")
     def test_softmax_3(self):
         t0 = torch.randn(3, 2, 1)
         t1 = torch.randn(2, 3, 1)
@@ -534,6 +544,7 @@ class TestFunctional(TestCase):
         nt = ntnt_nograd(ts)
         self._test_softmax(ts, nt)
 
+    @unittest.skip("Currently only supporting nested dim 1.")
     def test_softmax_4(self):
         ts = torch.randn(6, 4, 3, 2, 5)
         ts = list(map(lambda x: x.unbind(), ts.unbind()))
@@ -617,11 +628,12 @@ class TestFunctional(TestCase):
         t = torch.randn(2, 3)
         result = ntnt_nograd([t])
 
-        nt = ntnt_nograd([[t.reshape(1, 2, 1, 3)]])
-        # self.assertEqual(nt.squeeze(), result)
-        self.assertRaises(RuntimeError, lambda: nt.squeeze())
-        nt.squeeze_()
-        self.assertEqual(nt, result)
+        # Currently only supporting nested dim 1.
+        # nt = ntnt_nograd([[t.reshape(1, 2, 1, 3)]])
+        # # self.assertEqual(nt.squeeze(), result)
+        # self.assertRaises(RuntimeError, lambda: nt.squeeze())
+        # nt.squeeze_()
+        # self.assertEqual(nt, result)
 
         nt = ntnt_nograd([t.reshape(2, 3)])
         # self.assertEqual(nt.squeeze(), result)
@@ -629,11 +641,12 @@ class TestFunctional(TestCase):
         nt.squeeze_()
         self.assertEqual(nt, result)
 
-        nt = ntnt_nograd([[t.reshape(2, 3)]])
-        # self.assertEqual(nt.squeeze(), result)
-        self.assertRaises(RuntimeError, lambda: nt.squeeze())
-        nt.squeeze_()
-        self.assertEqual(nt, result)
+        # Currently only supporting nested dim 1.
+        # nt = ntnt_nograd([[t.reshape(2, 3)]])
+        # # self.assertEqual(nt.squeeze(), result)
+        # self.assertRaises(RuntimeError, lambda: nt.squeeze())
+        # nt.squeeze_()
+        # self.assertEqual(nt, result)
 
         nt = ntnt_nograd([t.reshape(1, 2, 3)])
         # self.assertEqual(nt.squeeze(), result)
@@ -647,11 +660,12 @@ class TestFunctional(TestCase):
         nt.squeeze_()
         self.assertEqual(nt, result)
 
-        nt = ntnt_nograd([[[t.reshape(1, 2, 3)]]])
-        # self.assertEqual(nt.squeeze(), result)
-        self.assertRaises(RuntimeError, lambda: nt.squeeze())
-        nt.squeeze_()
-        self.assertEqual(nt, result)
+        # Currently only supporting nested dim 1.
+        # nt = ntnt_nograd([[[t.reshape(1, 2, 3)]]])
+        # # self.assertEqual(nt.squeeze(), result)
+        # self.assertRaises(RuntimeError, lambda: nt.squeeze())
+        # nt.squeeze_()
+        # self.assertEqual(nt, result)
 
         # result = ntnt([t])
         # nt = ntnt([t.reshape(1, 2, 3)])
@@ -787,14 +801,15 @@ class TestFunctional(TestCase):
     @torch.inference_mode()
     def test_layer_norm(self):
         def _test(device):
-            layer_norm = torch.nn.LayerNorm((0,)).to(device)
-            t0 = torch.randn(3)
-            t1 = torch.randn(2)
-            t2 = torch.randn(3)
-            ts = [[t0, t1], [t2]]
-            nt = ntnt_nograd(ts, device=device)
-            self.assertRaisesRegex(RuntimeError,
-                                   "Cannot normalize across irregular dimension 2", lambda: layer_norm(nt))
+            # Currently only supporting nested dim 1.
+            # layer_norm = torch.nn.LayerNorm((0,)).to(device)
+            # t0 = torch.randn(3)
+            # t1 = torch.randn(2)
+            # t2 = torch.randn(3)
+            # ts = [[t0, t1], [t2]]
+            # nt = ntnt_nograd(ts, device=device)
+            # self.assertRaisesRegex(RuntimeError,
+            #                        "Cannot normalize across irregular dimension 2", lambda: layer_norm(nt))
 
             t0 = utils.gen_float_tensor(1, (2, 32)).to(device)
             t1 = utils.gen_float_tensor(2, (2, 32)).to(device)
@@ -815,28 +830,30 @@ class TestFunctional(TestCase):
             t0 = utils.gen_float_tensor(1, (3, 16)).to(device)
             t1 = utils.gen_float_tensor(2, (2, 16)).to(device)
             t2 = utils.gen_float_tensor(3, (3, 16)).to(device)
-            ts = [[t0, t1], [t2]]
-            result = ntnt_nograd(ts, device=device)
-            layer_norm(ts[0][0])
-            map(self.assertEqual, tuple(
-                map(lambda x: layer_norm(x), ts[0])), result[0])
-            map(self.assertEqual, tuple(
-                map(lambda x: layer_norm(x), ts[1])), result[1])
 
-            layer_norm = torch.nn.LayerNorm(3).to(device)
-            t0 = torch.randn(3, 3, 4)
-            t1 = torch.randn(2, 3, 4)
-            t2 = torch.randn(3, 3, 4)
-            ts = [[t0, t1], [t2]]
-            nt = ntnt_nograd(ts, device=device)
-            self.assertRaisesRegex(RuntimeError,
-                                   "Normalized shape \[3\] does not match the size of the last dimension \(4\) of input.",
-                                   lambda: layer_norm(nt))
+            # Currently only supporting nested dim 1.
+            # ts = [[t0, t1], [t2]]
+            # result = ntnt_nograd(ts, device=device)
+            # layer_norm(ts[0][0])
+            # map(self.assertEqual, tuple(
+            #     map(lambda x: layer_norm(x), ts[0])), result[0])
+            # map(self.assertEqual, tuple(
+            #     map(lambda x: layer_norm(x), ts[1])), result[1])
 
-            layer_norm = torch.nn.LayerNorm((3, 2, 4)).to(device)
-            self.assertRaisesRegex(RuntimeError,
-                                   "Currently only singleton tuples of integers supported for layer_norm.",
-                                   lambda: layer_norm(nt))
+            # layer_norm = torch.nn.LayerNorm(3).to(device)
+            # t0 = torch.randn(3, 3, 4)
+            # t1 = torch.randn(2, 3, 4)
+            # t2 = torch.randn(3, 3, 4)
+            # ts = [[t0, t1], [t2]]
+            # nt = ntnt_nograd(ts, device=device)
+            # self.assertRaisesRegex(RuntimeError,
+            #                        "Normalized shape \[3\] does not match the size of the last dimension \(4\) of input.",
+            #                        lambda: layer_norm(nt))
+
+            # layer_norm = torch.nn.LayerNorm((3, 2, 4)).to(device)
+            # self.assertRaisesRegex(RuntimeError,
+            #                        "Currently only singleton tuples of integers supported for layer_norm.",
+            #                        lambda: layer_norm(nt))
         _test(torch.device('cpu'))
         if torch.cuda.is_available():
             _test(torch.device('cuda'))

--- a/test/test_nested_tensor_masking.py
+++ b/test/test_nested_tensor_masking.py
@@ -15,24 +15,6 @@ class TestTensorMask(TestCase):
         TestCase.assertEqual(self,  mask, torch.tensor(False))
         TestCase.assertEqual(self,  tensor, torch.tensor([0]))
 
-        a = nt.nested_tensor([
-            nt.nested_tensor([])
-        ])
-
-        tensor, mask = a.to_tensor_mask()
-
-        TestCase.assertEqual(self, mask, torch.tensor(False))
-        TestCase.assertEqual(self, tensor, torch.tensor([[0]]))
-
-        a = nt.nested_tensor([
-            nt.nested_tensor([]),
-            nt.nested_tensor([])
-        ])
-
-        tensor, mask = a.to_tensor_mask()
-        TestCase.assertEqual(self, mask, torch.tensor(False))
-        TestCase.assertEqual(self, tensor, torch.tensor([[0], [0]]))
-
     # TODO once .to_list() bug fixed
     def test_empty_tensor(self):
         a = nt.nested_tensor([
@@ -41,14 +23,6 @@ class TestTensorMask(TestCase):
         self.assertRaisesRegex(RuntimeError,
                 "Empty tensors are not yet supported.",
                 lambda: a.to_tensor_mask())
-
-        a = nt.nested_tensor([
-            nt.nested_tensor([
-                torch.tensor([])
-            ])
-        ])
-        self.assertRaisesRegex(
-            RuntimeError, "Empty tensors are not yet supported.", lambda: a.to_tensor_mask())
 
     def test_single_scalar(self):
         a = nt.nested_tensor([
@@ -74,56 +48,17 @@ class TestTensorMask(TestCase):
             "Requested mask dimension 2 is bigger than dimension 1 of given NestedTensor.",
             lambda: a.to_tensor_mask(mask_dim=2))
 
-        a = nt.nested_tensor([
-            nt.nested_tensor([
-                torch.tensor(1, dtype=torch.bfloat16)
-            ])
-        ])
-
-        tensor, mask = a.to_tensor_mask()
-        TestCase.assertEqual(self, tensor, torch.tensor(
-            [[1]], dtype=torch.bfloat16))
-        TestCase.assertEqual(self, mask, torch.tensor(True))
-
-        tensor, mask = a.to_tensor_mask(mask_dim=0)
-        TestCase.assertEqual(self, tensor, torch.tensor(
-            [[1]], dtype=torch.bfloat16))
-        TestCase.assertEqual(self, mask, torch.tensor(True))
-
-        tensor, mask = a.to_tensor_mask(mask_dim=1)
-        TestCase.assertEqual(self, tensor, torch.tensor(
-            [[1]], dtype=torch.bfloat16))
-        TestCase.assertEqual(self, mask, torch.tensor([True]))
-
-        tensor, mask = a.to_tensor_mask(mask_dim=2)
-        TestCase.assertEqual(self, tensor, torch.tensor(
-            [[1]], dtype=torch.bfloat16))
-        TestCase.assertEqual(self, mask, torch.tensor([[True]]))
-
-        self.assertRaisesRegex(
-            RuntimeError,
-            "Requested mask dimension 3 is bigger than dimension 2 of given NestedTensor.",
-            lambda: a.to_tensor_mask(mask_dim=3))
-
     # TODO once .to_list() bug fixed
+    @unittest.skip("Currently only supporting nested dim 1.")
     def test_multi_scalar(self):
         # TODO: add test cases
-        # a = nt.nested_tensor([
-        #        torch.tensor(1),
-        #        torch.tensor(2),
-        #        torch.tensor(3)
-        #    ])
-        # tensor, mask = a.to_tensor_mask()
-
         a = nt.nested_tensor([
-            nt.nested_tensor([
-                torch.tensor(1),
-                torch.tensor(2),
-                torch.tensor(3)
-            ])
-        ])
-
+               torch.tensor(1),
+               torch.tensor(2),
+               torch.tensor(3)
+           ])
         tensor, mask = a.to_tensor_mask()
+
         TestCase.assertEqual(self, tensor, torch.tensor([[1, 2, 3]]))
         TestCase.assertEqual(self, mask, torch.tensor(True))
 
@@ -139,60 +74,6 @@ class TestTensorMask(TestCase):
             RuntimeError,
             "Requested mask dimension 3 is bigger than dimension 2 of given NestedTensor.",
             lambda: a.to_tensor_mask(mask_dim=3))
-
-        a = nt.nested_tensor([
-            nt.nested_tensor([
-                torch.tensor(1)
-            ]),
-            nt.nested_tensor([
-                torch.tensor(2)
-            ]),
-            nt.nested_tensor([
-                torch.tensor(3)
-            ])
-        ])
-        tensor, mask = a.to_tensor_mask()
-        TestCase.assertEqual(self, tensor, torch.tensor([[1], [2], [3]]))
-        TestCase.assertEqual(self, mask, torch.tensor(True))
-
-        tensor, mask = a.to_tensor_mask(mask_dim=1)
-        TestCase.assertEqual(self, tensor, torch.tensor([[1], [2], [3]]))
-        TestCase.assertEqual(self, mask, torch.tensor([True, True, True]))
-
-        tensor, mask = a.to_tensor_mask(mask_dim=2)
-        TestCase.assertEqual(self, tensor, torch.tensor([[1], [2], [3]]))
-        TestCase.assertEqual(
-            self, mask, torch.tensor([[True], [True], [True]]))
-
-    def test_scalar_and_empty_nt(self):
-        a = nt.nested_tensor([
-            nt.nested_tensor([]),
-            nt.nested_tensor([
-                torch.tensor(11, dtype=torch.long)
-            ])
-        ])
-
-        tensor, mask = a.to_tensor_mask()
-        TestCase.assertEqual(self, tensor, torch.tensor(
-            [[0], [11]], dtype=torch.long))
-        TestCase.assertEqual(self, mask, torch.tensor([False,  True]))
-
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not enabled.")
-    def test_scalar_and_empty_nt_cuda(self):
-        a = nt.nested_tensor([
-            nt.nested_tensor([], dtype=torch.long,
-                             device=torch.device('cuda')),
-            nt.nested_tensor([
-                torch.tensor(11, dtype=torch.long, device=torch.device('cuda'))
-            ])
-        ], dtype=torch.long, device=torch.device('cuda'))
-
-        # TODO: Fix this case together with C++ rewrite.
-        self.assertRaisesRegex(
-            RuntimeError, "Expected all tensors to be on the same device, but found at least two devices, cpu and cuda", lambda: a.to_tensor_mask())
-        # tensor, mask = a.to_tensor_mask()
-        # TestCase.assertEqual(self, tensor, torch.tensor([[0], [11]], dtype=torch.long, device='cuda'))
-        # TestCase.assertEqual(self, mask, torch.tensor([False,  True], device='cuda'))
 
     def test_single_tensor(self):
         a = nt.nested_tensor([
@@ -218,38 +99,6 @@ class TestTensorMask(TestCase):
             RuntimeError,
             "Requested mask dimension 3 is bigger than dimension 2 of given NestedTensor.",
             lambda: a.to_tensor_mask(mask_dim=3))
-
-        # Extra dim
-        a = nt.nested_tensor([
-            nt.nested_tensor([
-                torch.tensor([1])
-            ])
-        ])
-
-        tensor, mask = a.to_tensor_mask()
-        TestCase.assertEqual(self, tensor, torch.tensor([[[1]]]))
-        TestCase.assertEqual(self, mask, torch.tensor(True))
-
-        tensor, mask = a.to_tensor_mask(mask_dim=0)
-        TestCase.assertEqual(self, tensor, torch.tensor([[[1]]]))
-        TestCase.assertEqual(self, mask, torch.tensor(True))
-
-        tensor, mask = a.to_tensor_mask(mask_dim=1)
-        TestCase.assertEqual(self, tensor, torch.tensor([[[1]]]))
-        TestCase.assertEqual(self, mask, torch.tensor([True]))
-
-        tensor, mask = a.to_tensor_mask(mask_dim=2)
-        TestCase.assertEqual(self, tensor, torch.tensor([[[1]]]))
-        TestCase.assertEqual(self, mask, torch.tensor([[True]]))
-
-        tensor, mask = a.to_tensor_mask(mask_dim=3)
-        TestCase.assertEqual(self, tensor, torch.tensor([[[1]]]))
-        TestCase.assertEqual(self, mask, torch.tensor([[[True]]]))
-
-        self.assertRaisesRegex(
-            RuntimeError,
-            "Requested mask dimension 4 is bigger than dimension 3 of given NestedTensor.",
-            lambda: a.to_tensor_mask(mask_dim=4))
 
     def test_multi_tensor(self):
         a = nt.nested_tensor([
@@ -282,153 +131,6 @@ class TestTensorMask(TestCase):
         TestCase.assertEqual(
             self, mask, torch.tensor([[True], [True], [True]]))
 
-        a = nt.nested_tensor([
-            nt.nested_tensor([
-                torch.tensor([1]),
-                torch.tensor([2]),
-                torch.tensor([3])
-            ])
-        ])
-        tensor, mask = a.to_tensor_mask()
-        TestCase.assertEqual(self, tensor, torch.tensor([[[1], [2], [3]]]))
-        TestCase.assertEqual(self, mask, torch.tensor(True))
-
-        tensor, mask = a.to_tensor_mask(mask_dim=1)
-        TestCase.assertEqual(self, tensor, torch.tensor([[[1], [2], [3]]]))
-        TestCase.assertEqual(self, mask, torch.tensor([True]))
-
-        tensor, mask = a.to_tensor_mask(mask_dim=2)
-        TestCase.assertEqual(self, tensor, torch.tensor([[[1], [2], [3]]]))
-        TestCase.assertEqual(self, mask, torch.tensor([[True, True, True]]))
-
-        a = nt.nested_tensor([
-            nt.nested_tensor([
-                torch.tensor([1])
-            ]),
-            nt.nested_tensor([
-                torch.tensor([2])
-            ]),
-            nt.nested_tensor([
-                torch.tensor([3])
-            ])
-        ])
-        tensor, mask = a.to_tensor_mask()
-        TestCase.assertEqual(self, tensor, torch.tensor([[[1]], [[2]], [[3]]]))
-        TestCase.assertEqual(self, mask, torch.tensor(True))
-
-        tensor, mask = a.to_tensor_mask(mask_dim=1)
-        TestCase.assertEqual(self, tensor, torch.tensor([[[1]], [[2]], [[3]]]))
-        TestCase.assertEqual(self, mask, torch.tensor([True, True, True]))
-
-        tensor, mask = a.to_tensor_mask(mask_dim=2)
-        TestCase.assertEqual(self, tensor, torch.tensor([[[1]], [[2]], [[3]]]))
-        TestCase.assertEqual(
-            self, mask, torch.tensor([[True], [True], [True]]))
-
-    def test_multi_tensor2(self):
-        a = nt.nested_tensor([
-            nt.nested_tensor([
-                nt.nested_tensor([
-                    torch.tensor([[1, 2, 3, 4],
-                                  [5, 6, 7, 8]], dtype=torch.bfloat16, requires_grad=True)
-                ]),
-                nt.nested_tensor([
-                    torch.tensor([[0, 0], [3, 4]],
-                                 dtype=torch.bfloat16, requires_grad=True)
-                ]),
-                nt.nested_tensor([
-                    torch.tensor([[1]], dtype=torch.bfloat16,
-                                 requires_grad=True)
-                ]),
-            ])
-        ])
-
-        expected_t = torch.tensor([[
-            [[[1, 2, 3, 4],
-              [5, 6, 7, 8]]],
-            [[[0, 0, 0, 0],
-              [3, 4, 0, 0]]],
-            [[[1, 0, 0, 0],
-              [0, 0, 0, 0]]],
-        ]])
-
-        expected_m = torch.tensor([[
-            [[[True,  True,  True,  True],
-              [True,  True,  True,  True]]],
-            [[[True,  True, False, False],
-              [True,  True, False, False]]],
-            [[[True, False, False, False],
-              [False, False, False, False]]]]])
-
-        tensor, mask = a.to_tensor_mask()
-        TestCase.assertEqual(self, expected_t, tensor)
-        TestCase.assertEqual(self, expected_m, mask)
-
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not enabled.")
-    def test_multi_tensor2_cuda(self):
-        a = nt.nested_tensor([
-            nt.nested_tensor([
-                nt.nested_tensor([
-                    torch.tensor([[1, 2, 3, 4],
-                                  [5, 6, 7, 8]], dtype=torch.bfloat16, device='cuda', requires_grad=True)
-                ]),
-                nt.nested_tensor([
-                    torch.tensor(
-                        [[0, 0], [3, 4]], dtype=torch.bfloat16, device='cuda', requires_grad=True)
-                ]),
-                nt.nested_tensor([
-                    torch.tensor([[1]], dtype=torch.bfloat16,
-                                 device='cuda', requires_grad=True)
-                ]),
-            ])
-        ])
-
-        expected_t = torch.tensor([[
-            [[[1, 2, 3, 4],
-              [5, 6, 7, 8]]],
-            [[[0, 0, 0, 0],
-              [3, 4, 0, 0]]],
-            [[[1, 0, 0, 0],
-              [0, 0, 0, 0]]],
-        ]])
-
-        expected_m = torch.tensor([[
-            [[[True,  True,  True,  True],
-              [True,  True,  True,  True]]],
-            [[[True,  True, False, False],
-              [True,  True, False, False]]],
-            [[[True, False, False, False],
-              [False, False, False, False]]]]])
-
-        tensor, mask = a.to_tensor_mask()
-        TestCase.assertEqual(self, expected_t, tensor)
-        TestCase.assertEqual(self, expected_m, mask)
-
-    def test_multi_tensor3(self):
-        a = nt.nested_tensor([
-            nt.nested_tensor([
-                torch.tensor([[1, 2, 3], [4, 5, 6]]),
-                torch.tensor([[1, 2, 0, 4], [4, 0, 6, 5]]),
-                torch.tensor([[0, 0], [0, 0]])
-            ])
-        ])
-
-        expected_t = torch.tensor([[
-            [[1, 2, 3, 0], [4, 5, 6, 0]],
-            [[1, 2, 0, 4], [4, 0, 6, 5]],
-            [[0, 0, 0, 0], [0, 0, 0, 0]]
-        ]])
-
-        expected_m = torch.tensor([[
-            [[True, True, True, False], [True, True, True, False]],
-            [[True, True, True, True], [True, True, True, True]],
-            [[True, True, False, False], [True, True, False, False]]
-        ]])
-
-        tensor, mask = a.to_tensor_mask()
-        TestCase.assertEqual(self, expected_t, tensor)
-        TestCase.assertEqual(self, expected_m, mask)
-
     @torch.inference_mode()
     def test_mask_dim_too_small_error(self):
         a = nt.nested_tensor([
@@ -438,26 +140,6 @@ class TestTensorMask(TestCase):
 
         self.assertRaisesRegex(
             RuntimeError, "Mask dimension is too small to represent data tensor.", lambda: a.to_tensor_mask(mask_dim=1))
-
-        a = nt.nested_tensor([
-            nt.nested_tensor([
-                nt.nested_tensor([
-                    torch.tensor([[1, 2, 3, 4],
-                                  [5, 6, 7, 8]])
-                ]),
-                nt.nested_tensor([
-                    torch.tensor([[0, 0], [3, 4]])
-                ]),
-                nt.nested_tensor([
-                    torch.tensor([[1]])
-                ]),
-            ])
-        ])
-
-        for dim in range(4):
-            self.assertRaisesRegex(
-                RuntimeError, "Mask dimension is too small to represent data tensor.", lambda: a.to_tensor_mask(mask_dim=dim))
-
     #
     # Group of tests to test nested_tensor_from_tensor_mask()
     #
@@ -496,11 +178,6 @@ class TestTensorMask(TestCase):
             torch.tensor([]),
         ])
 
-        expected_nt2 = nt.nested_tensor([
-            nt.nested_tensor([]),
-            nt.nested_tensor([])
-        ])
-
         res_nt = nt.nested_tensor_from_tensor_mask(tensor, tensor)
         TestCase.assertEqual(self, res_nt, expected_nt1)
 
@@ -508,12 +185,12 @@ class TestTensorMask(TestCase):
             tensor, tensor, nested_dim=1)
         TestCase.assertEqual(self, res_nt, expected_nt1)
 
-        res_nt = nt.nested_tensor_from_tensor_mask(
-            tensor, tensor, nested_dim=2)
-        TestCase.assertEqual(self, res_nt, expected_nt2)
+        res_nt = nt.nested_tensor_from_tensor_mask(tensor, tensor)
+        TestCase.assertEqual(self, res_nt, expected_nt1)
 
-        self.assertRaises(RuntimeError, lambda: nt.nested_tensor_from_tensor_mask(
-            tensor, tensor, nested_dim=3))
+        res_nt = nt.nested_tensor_from_tensor_mask(
+            tensor, tensor, nested_dim=1)
+        TestCase.assertEqual(self, res_nt, expected_nt1)
 
     def test_ntftm_empty3(self):
         tensor = torch.tensor([0])
@@ -524,15 +201,6 @@ class TestTensorMask(TestCase):
 
         tensor = torch.tensor([[0], [0]])
         mask = torch.tensor([[False], [False]])
-
-        expected_nt = nt.nested_tensor([
-            nt.nested_tensor([]),
-            nt.nested_tensor([])
-        ])
-
-        res_nt = nt.nested_tensor_from_tensor_mask(
-            tensor, mask, nested_dim=expected_nt.nested_dim())
-        TestCase.assertEqual(self, res_nt, expected_nt)
 
     def test_ntftm_empty_error(self):
         tensor = torch.tensor([])
@@ -579,14 +247,6 @@ class TestTensorMask(TestCase):
                                  torch.tensor([1])
                              ]))
 
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
-        TestCase.assertEqual(self, res_nt,
-                             nt.nested_tensor([
-                                 nt.nested_tensor([
-                                     torch.tensor(1)
-                                 ])
-                             ]))
-
     def test_ntftm_multi_scalars(self):
         tensor = torch.tensor([1, 2, 3])
         mask = torch.tensor(True)
@@ -617,16 +277,6 @@ class TestTensorMask(TestCase):
         TestCase.assertEqual(self, res_nt,
                              nt.nested_tensor([
                                  torch.tensor([1, 2, 3])
-                             ], dtype=torch.int64))
-
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
-        TestCase.assertEqual(self, res_nt,
-                             nt.nested_tensor([
-                                 nt.nested_tensor([
-                                     torch.tensor(1),
-                                     torch.tensor(2),
-                                     torch.tensor(3)
-                                 ])
                              ], dtype=torch.int64))
 
     def test_ntftm_single_tensor_all_true_mask(self):
@@ -662,60 +312,11 @@ class TestTensorMask(TestCase):
         ], dtype=tensor.dtype)
         TestCase.assertEqual(self, res_nt, expected_res1)
 
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
-        expected_res2 = nt.nested_tensor([
-            nt.nested_tensor([
-                torch.tensor([1])
-            ]),
-            nt.nested_tensor([
-                torch.tensor([2])
-            ]),
-            nt.nested_tensor([
-                torch.tensor([3])
-            ])
-        ], dtype=tensor.dtype)
-        TestCase.assertEqual(self, res_nt, expected_res2)
-
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=3)
-        expected_res3 = nt.nested_tensor([
-            nt.nested_tensor([
-                nt.nested_tensor([
-                    torch.tensor(1)
-                ])
-            ]),
-            nt.nested_tensor([
-                nt.nested_tensor([
-                    torch.tensor(2)
-                ])
-            ]),
-            nt.nested_tensor([
-                nt.nested_tensor([
-                    torch.tensor(3)
-                ])
-            ])
-        ], dtype=tensor.dtype)
-        TestCase.assertEqual(self, res_nt, expected_res3)
-
-        self.assertRaises(RuntimeError, lambda: nt.nested_tensor_from_tensor_mask(
-            tensor, mask, nested_dim=4))
-
     def test_ntftm_multi_tensor_true_mask(self):
         extected_nt1 = nt.nested_tensor([
             torch.tensor([[1]]),
             torch.tensor([[2]]),
             torch.tensor([[3]])
-        ])
-
-        extected_nt2 = nt.nested_tensor([
-            nt.nested_tensor([
-                torch.tensor([1])
-            ]),
-            nt.nested_tensor([
-                torch.tensor([2])
-            ]),
-            nt.nested_tensor([
-                torch.tensor([3])
-            ])
         ])
 
         tensor = torch.tensor([[[1]],
@@ -730,34 +331,24 @@ class TestTensorMask(TestCase):
         res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask3)
         TestCase.assertEqual(self, extected_nt1, res_nt)
 
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask3, nested_dim=2)
-        TestCase.assertEqual(self, extected_nt2, res_nt)
-
         # Mask dim 2
         mask2 = torch.tensor([[True],
                               [True],
                               [True]])
+
         res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask2)
         TestCase.assertEqual(self, extected_nt1, res_nt)
 
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask2, nested_dim=2)
-        TestCase.assertEqual(self, extected_nt2, res_nt)
-
         # Mask dim 1
         mask1 = torch.tensor([True, True, True])
+
         res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask1)
         TestCase.assertEqual(self, extected_nt1, res_nt)
-
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask1, nested_dim=2)
-        TestCase.assertEqual(self, extected_nt2, res_nt)
 
         # Mask dim 0
         mask0 = torch.tensor(True)
         res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask0)
         TestCase.assertEqual(self, extected_nt1, res_nt)
-
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask0, nested_dim=2)
-        TestCase.assertEqual(self, extected_nt2, res_nt)
 
     def test_ntftm_single_tensor_all_false_mask(self):
         tensor = torch.tensor([[1]])
@@ -790,16 +381,6 @@ class TestTensorMask(TestCase):
                                  torch.tensor([], dtype=tensor.dtype)
                              ], dtype=torch.int64))
 
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=3)
-        TestCase.assertEqual(self, res_nt,
-                             nt.nested_tensor([
-                                 nt.nested_tensor([
-                                 ])
-                             ]))
-
-        self.assertRaises(RuntimeError, lambda: nt.nested_tensor_from_tensor_mask(
-            tensor, mask, nested_dim=4))
-
     def test_ntftm_multi_tensor_all_false_mask2(self):
         tensor = torch.tensor([[[1], [2], [3]]])
         mask = torch.tensor([[[False], [False], [False]]])
@@ -807,16 +388,6 @@ class TestTensorMask(TestCase):
         TestCase.assertEqual(self, res_nt,
                              nt.nested_tensor([
                                  torch.empty((3, 0), dtype=tensor.dtype)
-                             ], dtype=tensor.dtype))
-
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
-        TestCase.assertEqual(self, res_nt,
-                             nt.nested_tensor([
-                                 nt.nested_tensor([
-                                     torch.tensor([], dtype=tensor.dtype),
-                                     torch.tensor([], dtype=tensor.dtype),
-                                     torch.tensor([], dtype=tensor.dtype)
-                                 ])
                              ], dtype=tensor.dtype))
 
     def test_ntgtm_multi_scalar_mix_mask(self):
@@ -849,34 +420,13 @@ class TestTensorMask(TestCase):
             torch.tensor([11], dtype=torch.long)
         ])
 
-        expected_nt2 = nt.nested_tensor([
-            nt.nested_tensor([]),
-            nt.nested_tensor([
-                torch.tensor(11, dtype=torch.long)
-            ])
-        ])
-
         res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask)
         TestCase.assertEqual(self, expected_nt1, res_nt)
-
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
-        TestCase.assertEqual(self, expected_nt2, res_nt)
 
     def test_ntftm_test_multi_tensor_mix_mask(self):
         expected_nt1 = nt.nested_tensor([
             torch.tensor([1, 2, 3]),
             torch.tensor([4])
-        ])
-
-        expected_nt2 = nt.nested_tensor([
-            nt.nested_tensor([
-                torch.tensor(1),
-                torch.tensor(2),
-                torch.tensor(3)
-            ]),
-            nt.nested_tensor([
-                torch.tensor(4)
-            ])
         ])
 
         tensor = torch.tensor([[1, 2, 3],
@@ -887,37 +437,10 @@ class TestTensorMask(TestCase):
         res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=1)
         TestCase.assertEqual(self, expected_nt1, res_nt)
 
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
-        TestCase.assertEqual(self, expected_nt2, res_nt)
-
     def test_ntftm_test_multi_tensor_mix_mask2(self):
         expected_nt1 = nt.nested_tensor([
             torch.tensor([[1, 2, 3]]),
             torch.tensor([[4]])
-        ])
-
-        expected_nt2 = nt.nested_tensor([
-            nt.nested_tensor([
-                torch.tensor([1, 2, 3])
-            ]),
-            nt.nested_tensor([
-                torch.tensor([4])
-            ])
-        ])
-
-        expected_nt3 = nt.nested_tensor([
-            nt.nested_tensor([
-                nt.nested_tensor([
-                    torch.tensor(1),
-                    torch.tensor(2),
-                    torch.tensor(3)
-                ])
-            ]),
-            nt.nested_tensor([
-                nt.nested_tensor([
-                    torch.tensor(4)
-                ])
-            ])
         ])
 
         tensor = torch.tensor([[[1, 2, 3]],
@@ -928,194 +451,8 @@ class TestTensorMask(TestCase):
         res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=1)
         TestCase.assertEqual(self, expected_nt1, res_nt)
 
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
-        TestCase.assertEqual(self, expected_nt2, res_nt)
-
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=3)
-        TestCase.assertEqual(self, expected_nt3, res_nt)
-
         self.assertRaises(RuntimeError, lambda: nt.nested_tensor_from_tensor_mask(
             tensor, mask, nested_dim=4))
-
-    def test_ntftm_test_multi_tensor_mix_mask3(self):
-        expected_nt2 = nt.nested_tensor([
-            nt.nested_tensor([
-                torch.tensor([[[1, 2, 3, 4],
-                               [5, 6, 7, 8]]]),
-                torch.tensor([[[0, 0],
-                               [3, 4]]]),
-                torch.tensor([[[1]]])
-            ])
-        ])
-
-        expected_nt3 = nt.nested_tensor([
-            nt.nested_tensor([
-                nt.nested_tensor([
-                    torch.tensor([[1, 2, 3, 4],
-                                  [5, 6, 7, 8]])
-                ]),
-                nt.nested_tensor([
-                    torch.tensor([[0, 0],
-                                  [3, 4]])
-                ]),
-                nt.nested_tensor([
-                    torch.tensor([[1]])
-                ]),
-            ])
-        ])
-
-        expected_nt4 = nt.nested_tensor([
-            nt.nested_tensor([
-                nt.nested_tensor([
-                    nt.nested_tensor([
-                        torch.tensor([1, 2, 3, 4]),
-                        torch.tensor([5, 6, 7, 8])
-                    ])
-                ]),
-                nt.nested_tensor([
-                    nt.nested_tensor([
-                        torch.tensor([0, 0]),
-                        torch.tensor([3, 4])
-                    ])
-                ]),
-                nt.nested_tensor([
-                    nt.nested_tensor([
-                        torch.tensor([1]),
-                        torch.tensor([], dtype=torch.long)
-                    ])
-                ])
-            ])
-        ])
-
-        expected_nt5 = nt.nested_tensor([
-            nt.nested_tensor([
-                nt.nested_tensor([
-                    nt.nested_tensor([
-                        nt.nested_tensor([
-                            torch.tensor(1),
-                            torch.tensor(2),
-                            torch.tensor(3),
-                            torch.tensor(4)
-                        ]),
-                        nt.nested_tensor([
-                            torch.tensor(5),
-                            torch.tensor(6),
-                            torch.tensor(7),
-                            torch.tensor(8)
-                        ]),
-                    ])
-                ]),
-                nt.nested_tensor([
-                    nt.nested_tensor([
-                        nt.nested_tensor([
-                            torch.tensor(0),
-                            torch.tensor(0)
-                        ]),
-                        nt.nested_tensor([
-                            torch.tensor(3),
-                            torch.tensor(4)
-                        ])
-                    ])
-                ]),
-                nt.nested_tensor([
-                    nt.nested_tensor([
-                        nt.nested_tensor([
-                            torch.tensor(1)
-                        ]),
-                        nt.nested_tensor([
-                        ])
-                    ])
-                ])
-            ])
-        ])
-
-        tensor = torch.tensor([
-            [
-                [[[1, 2, 3, 4],
-                  [5, 6, 7, 8]]],
-                [[[0, 0, 0, 0],
-                  [3, 4, 0, 0]]],
-                [[[1, 0, 0, 0],
-                  [0, 0, 0, 0]]],
-            ]
-        ], dtype=torch.float)
-
-        mask = torch.tensor([[
-            [[[True,  True,  True,  True],
-              [True,  True,  True,  True]]],
-            [[[True,  True, False, False],
-              [True,  True, False, False]]],
-            [[[True, False, False, False],
-              [False, False, False, False]]]]])
-
-        self.assertRaises(RuntimeError, lambda: nt.nested_tensor_from_tensor_mask(
-            tensor, mask, nested_dim=1))
-
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=2)
-        TestCase.assertEqual(self, expected_nt2, res_nt)
-
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=3)
-        TestCase.assertEqual(self, expected_nt3, res_nt)
-
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=4)
-        TestCase.assertEqual(self, expected_nt4, res_nt)
-
-        res_nt = nt.nested_tensor_from_tensor_mask(tensor, mask, nested_dim=5)
-        TestCase.assertEqual(self, expected_nt5, res_nt)
-
-        self.assertRaises(RuntimeError, lambda: nt.nested_tensor_from_tensor_mask(
-            tensor, mask, nested_dim=6))
-
-    def test_ntftm_mask_dim(self):
-        a = nt.nested_tensor([
-            nt.nested_tensor([
-                nt.nested_tensor([
-                    torch.tensor([[1, 2, 3, 4],
-                                  [5, 6, 7, 8]], dtype=torch.float16, requires_grad=False)
-                ]),
-                nt.nested_tensor([
-                    torch.tensor([[1, 2, 3, 4],
-                                  [5, 6, 7, 8]], dtype=torch.float16, requires_grad=False)
-                ]),
-                nt.nested_tensor([
-                    torch.tensor([[1, 2, 3, 4],
-                                  [5, 6, 7, 8]], dtype=torch.float16, requires_grad=False)
-                ]),
-            ])
-        ])
-
-        for i in range(a.dim()):
-            t, m = a.to_tensor_mask(mask_dim=i)
-            res_nt = nt.nested_tensor_from_tensor_mask(
-                t, m, nested_dim=a.nested_dim())
-            TestCase.assertEqual(self, a, res_nt)
-            TestCase.assertEqual(self, res_nt.nested_dim(), a.nested_dim())
-
-    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not enabled.")
-    def test_ntftm_mask_dim_cuda(self):
-        a = nt.nested_tensor([
-            nt.nested_tensor([
-                nt.nested_tensor([
-                    torch.tensor([[1, 2, 3, 4],
-                                  [5, 6, 7, 8]], dtype=torch.float16, device='cuda', requires_grad=False)
-                ]),
-                nt.nested_tensor([
-                    torch.tensor([[1, 2, 3, 4],
-                                  [5, 6, 7, 8]], dtype=torch.float16, device='cuda', requires_grad=False)
-                ]),
-                nt.nested_tensor([
-                    torch.tensor([[1, 2, 3, 4],
-                                  [5, 6, 7, 8]], dtype=torch.float16, device='cuda', requires_grad=False)
-                ]),
-            ])
-        ])
-
-        for i in range(a.dim()):
-            t, m = a.to_tensor_mask(mask_dim=i)
-            res_nt = nt.nested_tensor_from_tensor_mask(
-                t, m, nested_dim=a.nested_dim())
-            TestCase.assertEqual(self, a, res_nt)
-            TestCase.assertEqual(self, res_nt.nested_dim(), a.nested_dim())
 
     def test_to_padded_tensor(self):
         data1 = torch.tensor(

--- a/test/test_nested_tensor_nary.py
+++ b/test/test_nested_tensor_nary.py
@@ -245,7 +245,8 @@ def _gen_test_binary_method(func):
 
 TestUnary = type('TestUnary', (DynamicClassBase,), {})
 for func__ in get_unary_functions():
-    for nested_dim in range(1, 5):
+    # TODO: Currently only supporting nested dim 1.
+    for nested_dim in [1]:
         avail_devices = [torch.device('cpu')]
         if torch.cuda.is_available():
             avail_devices += [torch.device('cuda')]

--- a/test/test_nested_tensor_reduce.py
+++ b/test/test_nested_tensor_reduce.py
@@ -24,41 +24,44 @@ def _flatten_nt(nt):
 class TestReduce(TestCase):
 
     def _test_reduce_dim(self, fn, associative=True, test_keep_dim=True, test_multi_dim=True):
-        t0 = torch.arange(9).float().reshape(3, 3)
-        t1 = torch.arange(6).float().reshape(2, 3)
-        t2 = torch.arange(9).float().reshape(3, 3)
-        ts = [[t0, t1], [t2, t1]]
-        nt = ntnt(ts)
-        if associative and test_multi_dim:
-            t01 = fn(torch.stack([fn(t0, 0), fn(t1, 0)]), 0)
-            t21 = fn(torch.stack([fn(t2, 0), fn(t1, 0)]), 0)
-            t02 = fn(torch.stack([fn(t0, 0), fn(t2, 0)]), 0)
-            t11 = fn(torch.stack([fn(t1, 0), fn(t1, 0)]), 0)
-            self.assertEqual(ntnt([t01, t21]), fn(nt, (1, 2)))
-            self.assertEqual(ntnt([t02, t11]), fn(nt, (0, 2)))
+        pass
+        # Currently only supporting nested dim 1.
+        # t0 = torch.arange(9).float().reshape(3, 3)
+        # t1 = torch.arange(6).float().reshape(2, 3)
+        # t2 = torch.arange(9).float().reshape(3, 3)
+        # ts = [[t0, t1], [t2, t1]]
+        # nt = ntnt(ts)
+        # if associative and test_multi_dim:
+        #     t01 = fn(torch.stack([fn(t0, 0), fn(t1, 0)]), 0)
+        #     t21 = fn(torch.stack([fn(t2, 0), fn(t1, 0)]), 0)
+        #     t02 = fn(torch.stack([fn(t0, 0), fn(t2, 0)]), 0)
+        #     t11 = fn(torch.stack([fn(t1, 0), fn(t1, 0)]), 0)
+        #     self.assertEqual(ntnt([t01, t21]), fn(nt, (1, 2)))
+        #     self.assertEqual(ntnt([t02, t11]), fn(nt, (0, 2)))
 
-            if test_keep_dim:
-                t01 = fn(torch.stack([fn(t0, 0), fn(t1, 0)]), 0, True)
-                t21 = fn(torch.stack([fn(t2, 0), fn(t1, 0)]), 0, True)
-                t02 = fn(torch.stack([fn(t0, 0), fn(t2, 0)]), 0, True)
-                t11 = fn(torch.stack([fn(t1, 0), fn(t1, 0)]), 0, True)
-                self.assertEqual(ntnt([[t01, t21]]), fn(nt, (1, 2), True))
-                self.assertEqual(ntnt([[t02, t11]]), fn(nt, (0, 2), True))
+        #     if test_keep_dim:
+        #         t01 = fn(torch.stack([fn(t0, 0), fn(t1, 0)]), 0, True)
+        #         t21 = fn(torch.stack([fn(t2, 0), fn(t1, 0)]), 0, True)
+        #         t02 = fn(torch.stack([fn(t0, 0), fn(t2, 0)]), 0, True)
+        #         t11 = fn(torch.stack([fn(t1, 0), fn(t1, 0)]), 0, True)
+        #         self.assertEqual(ntnt([[t01, t21]]), fn(nt, (1, 2), True))
+        #         self.assertEqual(ntnt([[t02, t11]]), fn(nt, (0, 2), True))
 
-        ts = [[t0, t1], [t2]]
-        nt = ntnt(ts)
-        self.assertRaises(RuntimeError, lambda: fn(nt, 0))
-        self.assertRaises(RuntimeError, lambda: fn(nt, 1))
-        self.assertEqual(ntnt([[fn(t0, 0), fn(t1, 0)],
-                               [fn(t2, 0)]]), fn(nt, 2))
-        self.assertEqual(ntnt([[fn(t0, 1), fn(t1, 1)],
-                               [fn(t2, 1)]]), fn(nt, 3))
-        if test_keep_dim:
-            self.assertEqual(ntnt([[fn(t0, 0, True), fn(t1, 0, True)],
-                                   [fn(t2, 0, True)]]), fn(nt, 2, True))
-            self.assertEqual(ntnt([[fn(t0, 1, True), fn(t1, 1, True)],
-                                   [fn(t2, 1, True)]]), fn(nt, 3, True))
-        self.assertRaises(IndexError, lambda: fn(nt, 4))
+        # Currently only supporting nested dim 1.
+        # ts = [[t0, t1], [t2]]
+        # nt = ntnt(ts)
+        # self.assertRaises(RuntimeError, lambda: fn(nt, 0))
+        # self.assertRaises(RuntimeError, lambda: fn(nt, 1))
+        # self.assertEqual(ntnt([[fn(t0, 0), fn(t1, 0)],
+        #                        [fn(t2, 0)]]), fn(nt, 2))
+        # self.assertEqual(ntnt([[fn(t0, 1), fn(t1, 1)],
+        #                        [fn(t2, 1)]]), fn(nt, 3))
+        # if test_keep_dim:
+        #     self.assertEqual(ntnt([[fn(t0, 0, True), fn(t1, 0, True)],
+        #                            [fn(t2, 0, True)]]), fn(nt, 2, True))
+        #     self.assertEqual(ntnt([[fn(t0, 1, True), fn(t1, 1, True)],
+        #                            [fn(t2, 1, True)]]), fn(nt, 3, True))
+        # self.assertRaises(IndexError, lambda: fn(nt, 4))
 
     def test_cumsum(self):
         self._test_reduce_dim(torch.cumsum, False, False)
@@ -103,14 +106,15 @@ class TestReduce(TestCase):
         test([t0, t1, t2])
         t0, t1, t2, t3, t4 = gen_ts()
         test([t0, t1, t2, t3])
-        t0, t1, t2, t3, t4 = gen_ts()
-        test([[t0], [t1, t2]])
-        t0, t1, t2, t3, t4 = gen_ts()
-        test([[t0, t1], [t2]])
-        t0, t1, t2, t3, t4 = gen_ts()
-        test([[t0, t1], [t2, t3]])
-        t0, t1, t2, t3, t4 = gen_ts()
-        test([[t0, t1], [t2, t3], [t4]])
+        # Currently only supporting nested dim 1.
+        # t0, t1, t2, t3, t4 = gen_ts()
+        # test([[t0], [t1, t2]])
+        # t0, t1, t2, t3, t4 = gen_ts()
+        # test([[t0, t1], [t2]])
+        # t0, t1, t2, t3, t4 = gen_ts()
+        # test([[t0, t1], [t2, t3]])
+        # t0, t1, t2, t3, t4 = gen_ts()
+        # test([[t0, t1], [t2, t3], [t4]])
 
     def test_sum_all(self):
         # self._test_allreduce(lambda x: x.sum(), True)
@@ -186,23 +190,24 @@ class TestReduce(TestCase):
         self.assertRaisesRegex(
             RuntimeError, "Can only reduce across nested dimensions of Tensor compliant shapes.", lambda: torch.var(nt, 0))
 
-        nt = ntnt([[t0, t1], [t2, t3]])
-        self.assertRaisesRegex(
-            RuntimeError, "Can only reduce across nested dimension 0.", lambda: torch.var(nt, 1))
-        self.assertRaisesRegex(
-            RuntimeError, "Can only reduce across nested dimensions if given nested tensor is of nested dimension 1.", lambda: torch.var(nt, 0))
-        t0_var0 = torch.var(t0, 0)
-        t1_var0 = torch.var(t1, 0)
-        t2_var0 = torch.var(t2, 0)
-        t3_var0 = torch.var(t3, 0)
-        self.assertEqual(
-            ntnt([[t0_var0, t1_var0], [t2_var0, t3_var0]]), torch.var(nt, 2))
-        t0_var1 = torch.var(t0, 1)
-        t1_var1 = torch.var(t1, 1)
-        t2_var1 = torch.var(t2, 1)
-        t3_var1 = torch.var(t3, 1)
-        self.assertEqual(
-            ntnt([[t0_var1, t1_var1], [t2_var1, t3_var1]]), torch.var(nt, 3))
+        # Currently only supporting nested dim 1.
+        # nt = ntnt([[t0, t1], [t2, t3]])
+        # self.assertRaisesRegex(
+        #     RuntimeError, "Can only reduce across nested dimension 0.", lambda: torch.var(nt, 1))
+        # self.assertRaisesRegex(
+        #     RuntimeError, "Can only reduce across nested dimensions if given nested tensor is of nested dimension 1.", lambda: torch.var(nt, 0))
+        # t0_var0 = torch.var(t0, 0)
+        # t1_var0 = torch.var(t1, 0)
+        # t2_var0 = torch.var(t2, 0)
+        # t3_var0 = torch.var(t3, 0)
+        # self.assertEqual(
+        #     ntnt([[t0_var0, t1_var0], [t2_var0, t3_var0]]), torch.var(nt, 2))
+        # t0_var1 = torch.var(t0, 1)
+        # t1_var1 = torch.var(t1, 1)
+        # t2_var1 = torch.var(t2, 1)
+        # t3_var1 = torch.var(t3, 1)
+        # self.assertEqual(
+        #     ntnt([[t0_var1, t1_var1], [t2_var1, t3_var1]]), torch.var(nt, 3))
 
     @unittest.skip("Not implemented - needed for autograd.")
     def test_sum_to_size(self):


### PR DESCRIPTION
In context of focus on inference this restricts various use cases, but also makes it easier to write efficient kernels.