### PR TITLE
resnext101_32x4d oriented optimized implementations for packed memory.

### DIFF
--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -41,11 +41,11 @@ fi
 NIGHTLY_DATE=20210606
 
 if [ "${CU_VERSION:-}" == cpu ] ; then
-    pip3 install --pre torch=1.10.0dev${NIGHTLY_DATE} torchvision==1.9.0dev${NIGHTLY_DATE} -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+    pip3 install -q --pre torch==1.10.0dev${NIGHTLY_DATE} torchvision==1.9.0dev${NIGHTLY_DATE} -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
     conda install -y ninja
     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" FORCE_CUDA=1 USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 else
-    pip3 install --pre torch==1.10.0dev${NIGHTLY_DATE}+cu102 torchvision==1.9.0dev${NIGHTLY_DATE}+cu102 -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
+    pip3 install -q --pre torch==1.10.0dev${NIGHTLY_DATE}+cu102 torchvision==1.9.0dev${NIGHTLY_DATE}+cu102 -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
     conda install -y ninja
     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 fi

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -41,11 +41,11 @@ fi
 NIGHTLY_DATE=20210606
 
 if [ "${CU_VERSION:-}" == cpu ] ; then
-    pip3 install --pre torch==1.9.0dev${NIGHTLY_DATE}+cu102 torchvision==1.9.0dev${NIGHTLY_DATE}+cu102 -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
+    pip3 install --pre torch==1.10.0dev${NIGHTLY_DATE}+cu102 torchvision==1.9.0dev${NIGHTLY_DATE}+cu102 -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
     conda install -y ninja
     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 else
-    pip3 install --pre torch=1.9.0dev${NIGHTLY_DATE} torchvision==1.9.0dev${NIGHTLY_DATE} -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+    pip3 install --pre torch=1.10.0dev${NIGHTLY_DATE} torchvision==1.9.0dev${NIGHTLY_DATE} -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
     conda install -y ninja
     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" FORCE_CUDA=1 USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 fi

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -38,7 +38,7 @@ else
    PYVSHORT=cp${PYVSHORT}-cp${PYVSHORT}m
 fi
 
-NIGHTLY_DATE=20210606
+NIGHTLY_DATE=20210614
 
 if [ "${CU_VERSION:-}" == cpu ] ; then
     pip3 install -q --pre torch==1.10.0dev${NIGHTLY_DATE} torchvision==0.11.0dev${NIGHTLY_DATE}+cpu -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -41,13 +41,13 @@ fi
 NIGHTLY_DATE=20210606
 
 if [ "${CU_VERSION:-}" == cpu ] ; then
-    pip3 install --pre torch==1.10.0dev${NIGHTLY_DATE}+cu102 torchvision==1.9.0dev${NIGHTLY_DATE}+cu102 -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
-    conda install -y ninja
-    PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
-else
     pip3 install --pre torch=1.10.0dev${NIGHTLY_DATE} torchvision==1.9.0dev${NIGHTLY_DATE} -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
     conda install -y ninja
     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" FORCE_CUDA=1 USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
+else
+    pip3 install --pre torch==1.10.0dev${NIGHTLY_DATE}+cu102 torchvision==1.9.0dev${NIGHTLY_DATE}+cu102 -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
+    conda install -y ninja
+    PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 fi
 
 # if [ "${CU_VERSION:-}" == cpu ] ; then

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -43,11 +43,11 @@ NIGHTLY_DATE=20210606
 if [ "${CU_VERSION:-}" == cpu ] ; then
     pip3 install -q --pre torch==1.10.0dev${NIGHTLY_DATE} torchvision==0.11.0dev${NIGHTLY_DATE}+cpu -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
     conda install -y ninja
-    PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" FORCE_CUDA=1 USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
+    PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 else
     pip3 install -q --pre torch==1.10.0dev${NIGHTLY_DATE}+cu102 torchvision==0.11.0dev${NIGHTLY_DATE}+cu102 -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
     conda install -y ninja
-    PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
+    PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" FORCE_CUDA=1 USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 fi
 
 # if [ "${CU_VERSION:-}" == cpu ] ; then

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -41,11 +41,11 @@ fi
 NIGHTLY_DATE=20210606
 
 if [ "${CU_VERSION:-}" == cpu ] ; then
-    pip3 install --pre torch==1.9.0dev{NIGHTLY_DATE} torchvision==1.9.0dev{NIGHTLY_DATE} -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
+    pip3 install --pre torch==1.9.0dev${NIGHTLY_DATE}+cu102 torchvision==1.9.0dev${NIGHTLY_DATE}+cu102 -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
     conda install -y ninja
     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 else
-    pip3 install --pre torch=1.9.0dev{NIGHTLY_DATE} torchvision==1.9.0dev{NIGHTLY_DATE} -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+    pip3 install --pre torch=1.9.0dev${NIGHTLY_DATE} torchvision==1.9.0dev${NIGHTLY_DATE} -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
     conda install -y ninja
     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" FORCE_CUDA=1 USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 fi

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -41,11 +41,11 @@ fi
 NIGHTLY_DATE=20210606
 
 if [ "${CU_VERSION:-}" == cpu ] ; then
-    pip3 install -q --pre torch==1.10.0dev${NIGHTLY_DATE} torchvision==1.9.0dev${NIGHTLY_DATE} -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+    pip3 install -q --pre torch==1.10.0dev${NIGHTLY_DATE} torchvision==0.11.0dev${NIGHTLY_DATE}+cpu -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
     conda install -y ninja
     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" FORCE_CUDA=1 USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 else
-    pip3 install -q --pre torch==1.10.0dev${NIGHTLY_DATE}+cu102 torchvision==1.9.0dev${NIGHTLY_DATE}+cu102 -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
+    pip3 install -q --pre torch==1.10.0dev${NIGHTLY_DATE}+cu102 torchvision==0.11.0dev${NIGHTLY_DATE}+cu102 -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
     conda install -y ninja
     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 fi

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -41,11 +41,11 @@ fi
 NIGHTLY_DATE=20210606
 
 if [ "${CU_VERSION:-}" == cpu ] ; then
-    pip3 install --pre torch==1.9.0dev{NIGHTLY_DATE} torchvision=1.9.0dev{NIGHTLY_DATE} -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
+    pip3 install --pre torch==1.9.0dev{NIGHTLY_DATE} torchvision==1.9.0dev{NIGHTLY_DATE} -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
     conda install -y ninja
     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 else
-    pip3 install --pre torch=1.9.0dev{NIGHTLY_DATE} torchvision=1.9.0dev{NIGHTLY_DATE} -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+    pip3 install --pre torch=1.9.0dev{NIGHTLY_DATE} torchvision==1.9.0dev{NIGHTLY_DATE} -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
     conda install -y ninja
     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" FORCE_CUDA=1 USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 fi

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -45,7 +45,7 @@ if [ "${CU_VERSION:-}" == cpu ] ; then
     conda install -y ninja
     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 else
-    pip3 install -q --pre torch==1.10.0dev${NIGHTLY_DATE}+cu102 torchvision==0.11.0dev${NIGHTLY_DATE}+cu102 -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
+    pip3 install -q --pre torch==1.10.0dev${NIGHTLY_DATE}+cu102 torchvision==0.11.0dev${NIGHTLY_DATE} -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
     conda install -y ninja
     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" FORCE_CUDA=1 USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 fi

--- a/.circleci/unittest/linux/scripts/install.sh
+++ b/.circleci/unittest/linux/scripts/install.sh
@@ -40,22 +40,20 @@ fi
 
 NIGHTLY_DATE=20210606
 
-# if [ "${CU_VERSION:-}" == cpu ] ; then
-#     pip install -q https://download.pytorch.org/whl/nightly/cpu/torch-1.10.0.dev${NIGHTLY_DATE}%2Bcpu-${PYVSHORT}-linux_x86_64.whl
-#     pip install -q https://download.pytorch.org/whl/nightly/cpu/torchvision-0.11.0.dev${NIGHTLY_DATE}%2Bcpu-${PYVSHORT}-linux_x86_64.whl
-#     conda install -y ninja
-#     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
-# else
-#     pip install -q https://download.pytorch.org/whl/nightly/cu102/torch-1.10.0.dev${NIGHTLY_DATE}%2Bcu102-${PYVSHORT}-linux_x86_64.whl
-#     pip install -q https://download.pytorch.org/whl/nightly/cu102/torchvision-0.11.0.dev${NIGHTLY_DATE}-${PYVSHORT}-linux_x86_64.whl
-#     conda install -y ninja
-#     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" FORCE_CUDA=1 USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
-# fi
-
 if [ "${CU_VERSION:-}" == cpu ] ; then
-    conda install -y pytorch torchvision cpuonly -c pytorch-nightly
+    pip3 install --pre torch==1.9.0dev{NIGHTLY_DATE} torchvision=1.9.0dev{NIGHTLY_DATE} -f https://download.pytorch.org/whl/nightly/cu102/torch_nightly.html
+    conda install -y ninja
     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 else
-    conda install -y pytorch torchvision cudatoolkit=10.2 -c pytorch-nightly
+    pip3 install --pre torch=1.9.0dev{NIGHTLY_DATE} torchvision=1.9.0dev{NIGHTLY_DATE} -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
+    conda install -y ninja
     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" FORCE_CUDA=1 USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
 fi
+
+# if [ "${CU_VERSION:-}" == cpu ] ; then
+#     conda install -y pytorch torchvision cpuonly -c pytorch-nightly
+#     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
+# else
+#     conda install -y pytorch torchvision cudatoolkit=10.2 -c pytorch-nightly
+#     PYTORCH_VERSION="$(python -c "import torch; print(torch.__version__)")" FORCE_CUDA=1 USE_NINJA=1 python setup.py develop bdist_wheel -d $WHEELS_FOLDER
+# fi

--- a/benchmarks/classy.py
+++ b/benchmarks/classy.py
@@ -42,9 +42,11 @@ def run_benchmark(iters, shapes, model, model_name, bsz):
 
     # Test
     outputs_nt = model(ts_nt)
+    import sys; sys.exit(1)
     model_outputs = _loop()
     for mo, ntmo in zip(model_outputs, outputs_nt.unbind()):
-        assert torch.allclose(mo.squeeze(0), ntmo, rtol=1e-4, atol=1e-5)
+        # Using float16 tolerances from torch/testing/_core.yp
+        assert torch.allclose(mo.squeeze(0), ntmo, rtol=1e-3, atol=1e-3)
 
     loop_time = benchmark_torch_function(iters, _loop)
     nt_time = benchmark_torch_function(iters, lambda: model(ts_nt))

--- a/benchmarks/classy.py
+++ b/benchmarks/classy.py
@@ -42,7 +42,7 @@ def run_benchmark(iters, shapes, model, model_name, bsz):
 
     # Test
     outputs_nt = model(ts_nt)
-    # import sys; sys.exit(1)
+    import sys; sys.exit(1)
     model_outputs = _loop()
     for mo, ntmo in zip(model_outputs, outputs_nt.unbind()):
         # Using float16 tolerances from torch/testing/_core.yp
@@ -68,7 +68,6 @@ if __name__ == "__main__":
         shapes = [(1, 3, random.randint(100, 150), random.randint(100, 150)) for _ in range(bsz)]
         run_benchmark(1, shapes, model, model_name, bsz)
 
-    _benchmark("resnext101_32x4d", 2)
     _benchmark("resnext101_32x4d", 64)
     _benchmark("resnext101_32x4d", 128)
     _benchmark("resnext101_32x4d", 256)

--- a/benchmarks/classy.py
+++ b/benchmarks/classy.py
@@ -42,7 +42,7 @@ def run_benchmark(iters, shapes, model, model_name, bsz):
 
     # Test
     outputs_nt = model(ts_nt)
-    import sys; sys.exit(1)
+    # import sys; sys.exit(1)
     model_outputs = _loop()
     for mo, ntmo in zip(model_outputs, outputs_nt.unbind()):
         # Using float16 tolerances from torch/testing/_core.yp
@@ -70,6 +70,6 @@ if __name__ == "__main__":
     _benchmark("resnext101_32x4d", 64)
     _benchmark("resnext101_32x4d", 128)
     _benchmark("resnext101_32x4d", 256)
-    _benchmark("regnet_y_128gf", 64)
-    _benchmark("regnet_y_128gf", 128)
-    _benchmark("regnet_y_128gf", 256)
+    # _benchmark("regnet_y_128gf", 64)
+    # _benchmark("regnet_y_128gf", 128)
+    # _benchmark("regnet_y_128gf", 256)

--- a/benchmarks/classy.py
+++ b/benchmarks/classy.py
@@ -45,8 +45,9 @@ def run_benchmark(iters, shapes, model, model_name, bsz):
     import sys; sys.exit(1)
     model_outputs = _loop()
     for mo, ntmo in zip(model_outputs, outputs_nt.unbind()):
+        pass
         # Using float16 tolerances from torch/testing/_core.yp
-        assert torch.allclose(mo.squeeze(0), ntmo, rtol=1e-3, atol=1e-3)
+        # assert torch.allclose(mo.squeeze(0), ntmo, rtol=1e-3, atol=1e-3)
 
     loop_time = benchmark_torch_function(iters, _loop)
     nt_time = benchmark_torch_function(iters, lambda: model(ts_nt))

--- a/benchmarks/classy.py
+++ b/benchmarks/classy.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
         model = build_model({"name": model_name})
         model = model.cuda().half().eval()
         random.seed(123)
-        shapes = [(1, 3, random.randint(100, 150), random.randint(100, 150)) for _ in range(bsz)]
+        shapes = [(1, 3, random.randint(100, 600), random.randint(100, 600)) for _ in range(bsz)]
         run_benchmark(1, shapes, model, model_name, bsz)
 
     _benchmark("resnext101_32x4d", 64)

--- a/benchmarks/classy.py
+++ b/benchmarks/classy.py
@@ -71,4 +71,5 @@ if __name__ == "__main__":
     _benchmark("resnext101_32x4d", 256)
     _benchmark("regnet_y_128gf", 64)
     _benchmark("regnet_y_128gf", 128)
-    _benchmark("regnet_y_128gf", 256)
+    # Runs out of memory
+    # _benchmark("regnet_y_128gf", 256)

--- a/benchmarks/classy.py
+++ b/benchmarks/classy.py
@@ -42,7 +42,7 @@ def run_benchmark(iters, shapes, model, model_name, bsz):
 
     # Test
     outputs_nt = model(ts_nt)
-    import sys; sys.exit(1)
+    # import sys; sys.exit(1)
     model_outputs = _loop()
     for mo, ntmo in zip(model_outputs, outputs_nt.unbind()):
         # Using float16 tolerances from torch/testing/_core.yp
@@ -68,9 +68,10 @@ if __name__ == "__main__":
         shapes = [(1, 3, random.randint(100, 150), random.randint(100, 150)) for _ in range(bsz)]
         run_benchmark(1, shapes, model, model_name, bsz)
 
+    _benchmark("resnext101_32x4d", 2)
     _benchmark("resnext101_32x4d", 64)
-    _benchmark("regnet_y_128gf", 64)
     _benchmark("resnext101_32x4d", 128)
-    _benchmark("regnet_y_128gf", 128)
     _benchmark("resnext101_32x4d", 256)
+    _benchmark("regnet_y_128gf", 64)
+    _benchmark("regnet_y_128gf", 128)
     _benchmark("regnet_y_128gf", 256)

--- a/benchmarks/classy.py
+++ b/benchmarks/classy.py
@@ -42,7 +42,7 @@ def run_benchmark(iters, shapes, model, model_name, bsz):
 
     # Test
     outputs_nt = model(ts_nt)
-    # import sys; sys.exit(1)
+    import sys; sys.exit(1)
     model_outputs = _loop()
     for mo, ntmo in zip(model_outputs, outputs_nt.unbind()):
         # Using float16 tolerances from torch/testing/_core.yp

--- a/benchmarks/classy.py
+++ b/benchmarks/classy.py
@@ -5,6 +5,7 @@ import random
 import nestedtensor
 from classy_vision.models import build_model
 
+
 @torch.inference_mode()
 def benchmark_torch_function(iters, f, *args, **kwargs):
     f(*args, **kwargs)
@@ -24,6 +25,7 @@ def benchmark_torch_function(iters, f, *args, **kwargs):
     else:
         return (time.time() - t0)
 
+
 @torch.inference_mode()
 def run_benchmark(iters, shapes, model, model_name, bsz):
     ts = []
@@ -38,10 +40,9 @@ def run_benchmark(iters, shapes, model, model_name, bsz):
             model_outputs.append(model(inp))
         return model_outputs
 
-    
     # Test
-    model_outputs = _loop()
     outputs_nt = model(ts_nt)
+    model_outputs = _loop()
     for mo, ntmo in zip(model_outputs, outputs_nt.unbind()):
         assert torch.allclose(mo.squeeze(0), ntmo, rtol=1e-4, atol=1e-5)
 

--- a/benchmarks/classy.py
+++ b/benchmarks/classy.py
@@ -42,7 +42,6 @@ def run_benchmark(iters, shapes, model, model_name, bsz):
 
     # Test
     outputs_nt = model(ts_nt)
-    import sys; sys.exit(1)
     model_outputs = _loop()
     for mo, ntmo in zip(model_outputs, outputs_nt.unbind()):
         # Using float16 tolerances from torch/testing/_core.yp
@@ -70,6 +69,6 @@ if __name__ == "__main__":
     _benchmark("resnext101_32x4d", 64)
     _benchmark("resnext101_32x4d", 128)
     _benchmark("resnext101_32x4d", 256)
-    # _benchmark("regnet_y_128gf", 64)
-    # _benchmark("regnet_y_128gf", 128)
-    # _benchmark("regnet_y_128gf", 256)
+    _benchmark("regnet_y_128gf", 64)
+    _benchmark("regnet_y_128gf", 128)
+    _benchmark("regnet_y_128gf", 256)

--- a/benchmarks/classy.py
+++ b/benchmarks/classy.py
@@ -42,12 +42,10 @@ def run_benchmark(iters, shapes, model, model_name, bsz):
 
     # Test
     outputs_nt = model(ts_nt)
-    import sys; sys.exit(1)
     model_outputs = _loop()
     for mo, ntmo in zip(model_outputs, outputs_nt.unbind()):
-        pass
         # Using float16 tolerances from torch/testing/_core.yp
-        # assert torch.allclose(mo.squeeze(0), ntmo, rtol=1e-3, atol=1e-3)
+        assert torch.allclose(mo.squeeze(0), ntmo, rtol=1e-3, atol=1e-3)
 
     loop_time = benchmark_torch_function(iters, _loop)
     nt_time = benchmark_torch_function(iters, lambda: model(ts_nt))
@@ -64,7 +62,6 @@ if __name__ == "__main__":
     def _benchmark(model_name, bsz):
         model = build_model({"name": model_name})
         model = model.cuda().half().eval()
-        
         random.seed(123)
         shapes = [(1, 3, random.randint(100, 150), random.randint(100, 150)) for _ in range(bsz)]
         run_benchmark(1, shapes, model, model_name, bsz)

--- a/benchmarks/classy.py
+++ b/benchmarks/classy.py
@@ -42,6 +42,7 @@ def run_benchmark(iters, shapes, model, model_name, bsz):
 
     # Test
     outputs_nt = model(ts_nt)
+    # import sys; sys.exit(1)
     model_outputs = _loop()
     for mo, ntmo in zip(model_outputs, outputs_nt.unbind()):
         # Using float16 tolerances from torch/testing/_core.yp

--- a/benchmarks/conv2d.py
+++ b/benchmarks/conv2d.py
@@ -1,0 +1,62 @@
+import torch
+import time
+import nestedtensor
+
+
+@torch.inference_mode()
+def benchmark_torch_function(iters, f, *args):
+    f(*args)
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+        start_event = torch.cuda.Event(enable_timing=True)
+        end_event = torch.cuda.Event(enable_timing=True)
+        start_event.record()
+    else:
+        t0 = time.time()
+    for _ in range(iters):
+        f(*args)
+    if torch.cuda.is_available():
+        end_event.record()
+        torch.cuda.synchronize()
+        return start_event.elapsed_time(end_event)
+    else:
+        return (time.time() - t0) * 1e3
+
+
+# def run(bdim, embedding_dim, out_dim, min_t, max_t, iters, device):
+def run(bdim, min_t, max_t, iters, device):
+    import random
+    random.seed(1010)
+
+    # The following is meant to emulate the lenghts of randomly sampled tokenized sentences
+    lengths1 = [random.randint(min_t, max_t) for _ in range(bdim)]
+    lengths2 = [random.randint(min_t, max_t) for _ in range(bdim)]
+
+    # List of sentence embeddings
+    tensors = [torch.rand(3, l1, l2).to(device=device, dtype=torch.float) for (l1, l2) in zip(lengths1, lengths2)]
+    # Create packed NestedTensor
+    nt = nestedtensor.nested_tensor(tensors, device=device, dtype=torch.float)
+
+    lin = torch.nn.Conv2d(3, 3, (1, 1)).to(device)
+
+    def _loop(tensors):
+        result = []
+        for t in tensors:
+            result.append(lin(t.unsqueeze(0)).squeeze(0))
+        return result
+
+    # Projects embeddings into another space
+    nt_time = benchmark_torch_function(iters, lin, nt)
+    t_time = benchmark_torch_function(iters, _loop, tensors)
+
+    # print(f"batch size: {bdim:4.0f}, embedding dim: {embedding_dim}, out_dim: {out_dim}, T mean:{lengths_mean:5.0f}, T std: {lengths_std:4.0f}", end='')
+    print(f"batch size: {bdim:4.0f}", end='')
+    # print(f", padding: {percentage_padded:3.0f}%, NT: {nt_time/iters:4.0f}ms, T: {t_time/iters:4.0f}ms, Speedup: {t_time/nt_time:3.2f}x")
+    print(f", NT: {nt_time/iters:4.0f}ms, T: {t_time/iters:4.0f}ms, Speedup: {t_time/nt_time:3.2f}x")
+
+
+if torch.cuda.is_available():
+    print("CUDA device: ", torch.cuda.get_device_name(0))
+iters = 10
+for min_t, max_t in [(16, 128), (32, 128), (64, 128), (128, 128)]:
+    run(256, min_t, max_t, iters, torch.device('cuda'))

--- a/nestedtensor/csrc/BinaryOps.cpp
+++ b/nestedtensor/csrc/BinaryOps.cpp
@@ -15,8 +15,6 @@ Tensor NestedTensor_add_Tensor(
     const Scalar& alpha) {
   Tensor self = self_;
   Tensor other = other_;
-  // std::cout << "add self: " << is_nested_tensor_impl(self) << std::endl;
-  // std::cout << "add other: " << is_nested_tensor_impl(other) << std::endl;
   if (is_nested_tensor_impl(self) && is_nested_tensor_impl(other)) {
     EfficientSizeNode self_efficient_nested_size =
         get_efficient_nested_size(self);
@@ -53,16 +51,10 @@ Tensor NestedTensor_add_Tensor(
         other.dtype() == c10::ScalarType::Half) {
       other = other.contiguous();
       at::Tensor self_buffer = get_buffer(self);
-      // std::cout << "self_buffer.is_contiguous(): " << self_buffer.is_contiguous() << std::endl;
-      // std::cout << "other.is_contiguous(): " << other.is_contiguous() << std::endl;
       Tensor nt_sizes_ =
           get_efficient_nested_size(self).sizes().to(torch::kInt32);
-      // std::cout << "nt_sizes_: " << nt_sizes_ << std::endl;
       Tensor nt_sizes_1 = at::native::narrow(nt_sizes_, 1, 1, 1);
       Tensor nt_sizes_2 = at::native::narrow(nt_sizes_, 1, 2, 1);
-      // std::cout << "nt_sizes_1: " << nt_sizes_1 << std::endl;
-      // std::cout << "nt_sizes_2: " << nt_sizes_2 << std::endl;
-      // Tensor nt_sizes_all = nt_sizes_0 * nt_sizes_1 * nt_sizes_2;
       Tensor nt_sizes_all = nt_sizes_1 * nt_sizes_2;
       std::vector<int> numbers;
       for (int64_t i = 0; i < nt_sizes_all.size(0); i++) {
@@ -70,48 +62,28 @@ Tensor NestedTensor_add_Tensor(
           numbers.push_back(nt_sizes_all[i].item<int>());
         }
       }
-      // std::cout << "nt_sizes_all: " << nt_sizes_all << std::endl;
       at::Tensor numbers_t = torch::tensor(numbers).to(torch::kInt32);
-      // std::cout << "numbers_t: " << numbers_t << std::endl;
       Tensor nt_sizes_cumsum =
           at::native::cumsum(numbers_t, 0).to(torch::kInt32).reshape({-1});
-      // std::cout << "nt_sizes_cumsum: " << nt_sizes_cumsum << std::endl;
       TORCH_CHECK(nt_sizes_.dim() == 2, "NestedTensor metadata of unexpected dimension.")
       Tensor nt_sizes = at::cat({torch::tensor({0}, torch::kInt32), nt_sizes_cumsum});
-      // std::cout << "nt_sizes: " << nt_sizes << std::endl;
       nt_sizes = nt_sizes.to(torch::kCUDA);
       at::cuda::CUDAStream defaultStream = at::cuda::getDefaultCUDAStream();
       at::Tensor result_buffer = self_buffer.clone();
 
-      // std::cout << "self.dtype(): " << self.dtype() << std::endl;
-      // std::cout << "other.dtype(): " << other.dtype() << std::endl;
-
-      Half* self_ptr = self_buffer.data_ptr<Half>();
-      Half* other_ptr = other.data_ptr<Half>();
-      Half* result_ptr = result_buffer.data_ptr<Half>();
-      // std::cout << "*self_opt_sizes[0]: " << *self_opt_sizes[0] << std::endl;
-      // std::cout << "*self_opt_sizes[1]: " << *self_opt_sizes[1] << std::endl;
-      // std::cout << "other.sizes(): " << other.sizes() << std::endl;
+      c10::Half* self_ptr = self_buffer.data_ptr<c10::Half>();
+      c10::Half* other_ptr = other.data_ptr<c10::Half>();
+      c10::Half* result_ptr = result_buffer.data_ptr<c10::Half>();
       nested_tensor::cuda::add_scalar_kernelLauncher(
-          reinterpret_cast<__half*>(self_ptr),
-          reinterpret_cast<__half*>(other_ptr),
-          reinterpret_cast<__half*>(result_ptr),
+          self_ptr,
+          other_ptr,
+          result_ptr,
           (int)(*self_opt_sizes[0] * *self_opt_sizes[1]),
           (int)(*self_opt_sizes[0]),
           nt_sizes.data_ptr<int>(),
           defaultStream);
-      // std::cout << "result_buffer: " << result_buffer << std::endl;
       return wrap_buffer(std::move(result_buffer), get_efficient_nested_size(self),
           get_efficient_nested_stride(self));
-      // std::cout << "nt_sizes: " << nt_sizes << std::endl;
-      // exit(1);
-      // std::cout << "special other.sizes(): " << other.sizes() << std::endl;
-      // std::tie(self, other) = _expand_other_as(self_, other_);
-      // return map_nested_tensor(
-      //     [&alpha](Tensor s, Tensor o) { 
-      //     return at::add(s, o, alpha); },
-      //     self,
-      //     other);
     }
 #endif
     if (self_opt_sizes[self_dim - 1] && other.dim() == 1 &&
@@ -129,8 +101,6 @@ Tensor NestedTensor_add_Tensor(
   std::tie(self, other) = _expand_other_as(self_, other_);
   return map_nested_tensor(
       [&alpha](Tensor s, Tensor o) { 
-      // std::cout << "s.sizes(): " << s.sizes() << std::endl;
-      // std::cout << "o.sizes(): " << o.sizes() << std::endl;
       return at::add(s, o, alpha); },
       self,
       other);
@@ -143,12 +113,8 @@ Tensor& NestedTensor_add__Tensor(
   at::Tensor self;
   at::Tensor other;
   std::tie(self, other) = _expand_other_as(self_, other_);
-  std::cout << "add_ self: " << is_nested_tensor_impl(self) << std::endl;
-  std::cout << "add_ other: " << is_nested_tensor_impl(other) << std::endl;
   apply_nested_tensor(
       [&alpha](Tensor& tensor, const Tensor other) {
-      std::cout << "tensr.sizes(): " << tensor.sizes() << std::endl;
-      std::cout << "other.sizes(): " << other.sizes() << std::endl;
         tensor.add_(other, alpha);
         return tensor;
       },
@@ -303,13 +269,13 @@ Tensor NestedTensor_mul_Tensor(const Tensor& self_, const Tensor& other_) {
       at::cuda::CUDAStream defaultStream = at::cuda::getDefaultCUDAStream();
       at::Tensor result_buffer = self_buffer.clone();
 
-      Half* self_ptr = self_buffer.data_ptr<Half>();
-      Half* other_ptr = other.data_ptr<Half>();
-      Half* result_ptr = result_buffer.data_ptr<Half>();
+      c10::Half* self_ptr = self_buffer.data_ptr<c10::Half>();
+      c10::Half* other_ptr = other.data_ptr<c10::Half>();
+      c10::Half* result_ptr = result_buffer.data_ptr<c10::Half>();
       nested_tensor::cuda::mul_scalar_kernelLauncher(
-          reinterpret_cast<__half*>(self_ptr),
-          reinterpret_cast<__half*>(other_ptr),
-          reinterpret_cast<__half*>(result_ptr),
+          self_ptr,
+          other_ptr,
+          result_ptr,
           (int)(*self_opt_sizes[0] * *self_opt_sizes[1]),
           (int)(*self_opt_sizes[0]),
           nt_sizes.data_ptr<int>(),
@@ -322,8 +288,6 @@ Tensor NestedTensor_mul_Tensor(const Tensor& self_, const Tensor& other_) {
   std::tie(self, other) = _expand_other_as(self_, other_);
   return map_nested_tensor(
       [](Tensor s, Tensor o) { 
-      std::cout << "mul special s.sizes(): " << s.sizes() << std::endl;
-      std::cout << "mul special o.sizes(): " << o.sizes() << std::endl;
       return at::mul(s, o); }, self, other);
 }
 
@@ -386,11 +350,64 @@ Tensor NestedTensor_sub_Tensor(
     const Tensor& self_,
     const Tensor& other_,
     const Scalar& alpha) {
-  Tensor self;
-  Tensor other;
+  Tensor self = self_;
+  Tensor other = other_;
+  if (is_nested_tensor_impl(self) && !is_nested_tensor_impl(other)) {
+    self = NestedTensor_contiguous(self);
+    int64_t self_dim = get_dim(self);
+    auto self_opt_sizes = get_opt_sizes(self);
+#ifdef WITH_CUDA
+    if (self_dim == 4 && other.dim() == 4 &&
+        self_opt_sizes[0] &&
+        self_opt_sizes[1] &&
+        (*self_opt_sizes[1]) == other.size(1) &&
+        other.size(0) == 1 &&
+        other.size(2) == 1 &&
+        other.size(3) == 1 &&
+        self.dtype() ==  c10::ScalarType::Half &&
+        other.dtype() == c10::ScalarType::Half) {
+      other = other.contiguous();
+      at::Tensor self_buffer = get_buffer(self);
+      Tensor nt_sizes_ =
+          get_efficient_nested_size(self).sizes().to(torch::kInt32);
+      Tensor nt_sizes_1 = at::native::narrow(nt_sizes_, 1, 1, 1);
+      Tensor nt_sizes_2 = at::native::narrow(nt_sizes_, 1, 2, 1);
+      Tensor nt_sizes_all = nt_sizes_1 * nt_sizes_2;
+      std::vector<int> numbers;
+      for (int64_t i = 0; i < nt_sizes_all.size(0); i++) {
+        for (int64_t j = 0; j < *self_opt_sizes[1]; j++) {
+          numbers.push_back(nt_sizes_all[i].item<int>());
+        }
+      }
+      at::Tensor numbers_t = torch::tensor(numbers).to(torch::kInt32);
+      Tensor nt_sizes_cumsum =
+          at::native::cumsum(numbers_t, 0).to(torch::kInt32).reshape({-1});
+      TORCH_CHECK(nt_sizes_.dim() == 2, "NestedTensor metadata of unexpected dimension.")
+      Tensor nt_sizes = at::cat({torch::tensor({0}, torch::kInt32), nt_sizes_cumsum});
+      nt_sizes = nt_sizes.to(torch::kCUDA);
+      at::cuda::CUDAStream defaultStream = at::cuda::getDefaultCUDAStream();
+      at::Tensor result_buffer = self_buffer.clone();
+
+      c10::Half* self_ptr = self_buffer.data_ptr<c10::Half>();
+      c10::Half* other_ptr = other.data_ptr<c10::Half>();
+      c10::Half* result_ptr = result_buffer.data_ptr<c10::Half>();
+      nested_tensor::cuda::sub_scalar_kernelLauncher(
+          self_ptr,
+          other_ptr,
+          result_ptr,
+          (int)(*self_opt_sizes[0] * *self_opt_sizes[1]),
+          (int)(*self_opt_sizes[0]),
+          nt_sizes.data_ptr<int>(),
+          defaultStream);
+      return wrap_buffer(std::move(result_buffer), get_efficient_nested_size(self),
+          get_efficient_nested_stride(self));
+    }
+#endif
+  }
   std::tie(self, other) = _expand_other_as(self_, other_);
   return map_nested_tensor(
-      [&alpha](Tensor s, Tensor o) { return at::sub(s, o, alpha); },
+      [&alpha](Tensor s, Tensor o) { 
+      return at::sub(s, o, alpha); },
       self,
       other);
 }

--- a/nestedtensor/csrc/BinaryOps.cpp
+++ b/nestedtensor/csrc/BinaryOps.cpp
@@ -10,6 +10,8 @@ Tensor NestedTensor_add_Tensor(
     const Scalar& alpha) {
   Tensor self = self_;
   Tensor other = other_;
+  std::cout << "add self: " << is_nested_tensor_impl(self) << std::endl;
+  std::cout << "add other: " << is_nested_tensor_impl(other) << std::endl;
   if (is_nested_tensor_impl(self) && is_nested_tensor_impl(other)) {
     EfficientSizeNode self_efficient_nested_size =
         get_efficient_nested_size(self);
@@ -48,7 +50,10 @@ Tensor NestedTensor_add_Tensor(
   }
   std::tie(self, other) = _expand_other_as(self_, other_);
   return map_nested_tensor(
-      [&alpha](Tensor s, Tensor o) { return at::add(s, o, alpha); },
+      [&alpha](Tensor s, Tensor o) { 
+      std::cout << "s.sizes(): " << s.sizes() << std::endl;
+      std::cout << "o.sizes(): " << o.sizes() << std::endl;
+      return at::add(s, o, alpha); },
       self,
       other);
 }
@@ -60,8 +65,12 @@ Tensor& NestedTensor_add__Tensor(
   at::Tensor self;
   at::Tensor other;
   std::tie(self, other) = _expand_other_as(self_, other_);
+  std::cout << "add_ self: " << is_nested_tensor_impl(self) << std::endl;
+  std::cout << "add_ other: " << is_nested_tensor_impl(other) << std::endl;
   apply_nested_tensor(
       [&alpha](Tensor& tensor, const Tensor other) {
+      std::cout << "tensr.sizes(): " << tensor.sizes() << std::endl;
+      std::cout << "other.sizes(): " << other.sizes() << std::endl;
         tensor.add_(other, alpha);
         return tensor;
       },

--- a/nestedtensor/csrc/activation.cpp
+++ b/nestedtensor/csrc/activation.cpp
@@ -35,6 +35,14 @@ Tensor NestedTensor_relu(const Tensor& self) {
 
 // Registered below autograd
 Tensor& NestedTensor_relu_(Tensor& self) {
+  if (get_is_contiguous(self)) {
+#ifdef TRACEPACKED
+    std::cout << "calling packed relu_" << std::endl;
+#endif
+    Tensor buffer = get_buffer(self);
+    at::relu_(buffer);
+    return self;
+  }
   apply_nested_tensor([](at::Tensor& tensor) { at::relu_(tensor); }, self);
   return self;
 }

--- a/nestedtensor/csrc/activation.cpp
+++ b/nestedtensor/csrc/activation.cpp
@@ -27,7 +27,9 @@ Tensor NestedTensor_relu(const Tensor& self) {
 #ifdef TRACEPACKED
     std::cout << "calling packed relu" << std::endl;
 #endif
-    return wrap_buffer(at::relu(get_buffer(self)), impl->nested_size());
+    return wrap_buffer(at::relu(get_buffer(self)),
+        get_efficient_nested_size(self),
+        get_efficient_nested_stride(self));
   }
   return map_nested_tensor(
       [](at::Tensor tensor) { return at::relu(tensor); }, self);

--- a/nestedtensor/csrc/autograd_functions.cpp
+++ b/nestedtensor/csrc/autograd_functions.cpp
@@ -2,6 +2,11 @@
 #include <nestedtensor/csrc/utils/nested_node_functions.h>
 #include <torch/extension.h>
 #include <torch/library.h>
+#ifdef WITH_CUDA
+#include <c10/cuda/CUDAStream.h>
+#include <nestedtensor/csrc/cuda/add.h>
+#include <c10/util/Half.h>
+#endif
 
 using namespace torch::nn;
 namespace F = torch::nn::functional;
@@ -89,19 +94,10 @@ Tensor NestedTensor_batch_norm(
     bool cudnn_enabled) {
   auto opt_sizes = get_nested_tensor_impl(input)->opt_sizes();
   TORCH_CHECK(opt_sizes[1], "batch norm requires regular second dimension.");
+  TORCH_CHECK(!training, "batch norm does not support training.");
   int64_t n_input = *opt_sizes[1];
-  if (running_mean) {
-    check_dims_match_num_input_features(
-        "running_mean", n_input, get_numel(*running_mean));
-  } else if (!training) {
-    AT_ERROR("running_mean must be defined in evaluation mode");
-  }
-  if (running_var) {
-    check_dims_match_num_input_features(
-        "running_var", n_input, get_numel(*running_var));
-  } else if (!training) {
-    AT_ERROR("running_var must be defined in evaluation mode");
-  }
+  TORCH_CHECK(running_mean, "running_mean must be defined in evaluation mode");
+  TORCH_CHECK(running_var, "running_var must be defined in evaluation mode");
   if (weight) {
     check_dims_match_num_input_features("weight", n_input, get_numel(*weight));
   }
@@ -110,52 +106,97 @@ Tensor NestedTensor_batch_norm(
   }
 
   auto scalar_shape = make_scalar_shape(get_dim(input), n_input);
+  // std::cout << "IntArrayRef(scalar_shape): " << IntArrayRef(scalar_shape) << std::endl;
+  // std::cout << "weight.has_value(): " << weight.has_value() << std::endl;
+  // std::cout << "bias.has_value(): " << bias.has_value() << std::endl;
+  // std::cout << "is_nested_tensor_impl(running_mean): " << is_nested_tensor_impl(*running_mean) << std::endl;
+  // std::cout << "is_nested_tensor_impl(running_var): " << is_nested_tensor_impl(*running_var) << std::endl;
+  // std::cout << "is_nested_tensor_impl(bias): " << is_nested_tensor_impl(*bias) << std::endl;
+  // std::cout << "is_nested_tensor_impl(weight): " << is_nested_tensor_impl(*weight) << std::endl;
+  // std::cout << "(running_mean): " << (*running_mean).sizes() << std::endl;
+  // std::cout << "(running_var): " << (*running_var).sizes() << std::endl;
+  // std::cout << "(bias): " << (*bias).sizes() << std::endl;
+  // std::cout << "(weight): " << (*weight).sizes() << std::endl;
+  // map([](std::vector<int64_t> size) {
+  //     std::cout << "IntArrayRef(size): " << IntArrayRef(size) << std::endl;
+  //     return size;
+  //     }, get_nested_size(input));
 
   at::Tensor mean;
   at::Tensor invstd;
-  at::Tensor save_mean;
-  at::Tensor save_invstd;
 
-  if (training) {
-    auto reduce_dims = make_reduce_dims(get_dim(input));
-    save_mean = at::mean(input, IntArrayRef(reduce_dims));
 
-    save_invstd =
-        1 / at::sqrt(at::var(input, IntArrayRef(reduce_dims), false) + eps);
+  mean = *running_mean;
+  invstd = 1 / at::sqrt(*running_var + eps);
+  // mean = mean.to(torch::kHalf);
+  // invstd = invstd.to(torch::kHalf);
 
-    if (running_mean) {
-      at::Tensor running_mean_(running_mean->getIntrusivePtr());
-      running_mean_ = running_mean_.detach();
-      running_mean_.copy_(
-          momentum * save_mean + (1 - momentum) * running_mean_);
-    }
 
-    if (running_var) {
-      Tensor unbiased_var = at::var(input, IntArrayRef(reduce_dims));
-      at::Tensor running_var_(running_var->getIntrusivePtr());
-      running_var_ = running_var_.detach();
-      running_var_.copy_(
-          momentum * unbiased_var + (1 - momentum) * running_var_);
-    }
-
-    mean = save_mean;
-    invstd = save_invstd;
-  } else {
-    mean = *running_mean;
-    invstd = 1 / at::sqrt(*running_var + eps);
-  }
+  // Custom CUDA Half implementation.
+  mean = mean.contiguous();
+  invstd = invstd.contiguous();
+  Tensor bias_cont = (*bias).contiguous();
+  Tensor weight_cont = (*weight).contiguous();
 
   Tensor output = input;
-  output = output - mean.reshape(IntArrayRef(scalar_shape));
-  output = output * invstd.reshape(IntArrayRef(scalar_shape));
+  output = NestedTensor_contiguous(output);
+  Tensor input_buffer = get_buffer(output);
+  Tensor output_buffer = input_buffer.clone();
 
-  if (weight) {
-    output = output * weight->reshape(IntArrayRef(scalar_shape));
+  auto self_opt_sizes = get_opt_sizes(input);
+
+  Tensor nt_sizes_ =
+      get_efficient_nested_size(input).sizes().to(torch::kInt32);
+  Tensor nt_sizes_1 = at::native::narrow(nt_sizes_, 1, 1, 1);
+  Tensor nt_sizes_2 = at::native::narrow(nt_sizes_, 1, 2, 1);
+  Tensor nt_sizes_all = nt_sizes_1 * nt_sizes_2;
+  std::vector<int> numbers;
+  for (int64_t i = 0; i < nt_sizes_all.size(0); i++) {
+    for (int64_t j = 0; j < *self_opt_sizes[1]; j++) {
+      numbers.push_back(nt_sizes_all[i].item<int>());
+    }
   }
-  if (bias) {
-    output = output + bias->reshape(IntArrayRef(scalar_shape));
-  }
-  return output;
+  at::Tensor numbers_t = torch::tensor(numbers).to(torch::kInt32);
+  Tensor nt_sizes_cumsum =
+      at::native::cumsum(numbers_t, 0).to(torch::kInt32).reshape({-1});
+  TORCH_CHECK(nt_sizes_.dim() == 2, "NestedTensor metadata of unexpected dimension.")
+  Tensor nt_sizes = at::cat({torch::tensor({0}, torch::kInt32), nt_sizes_cumsum});
+  nt_sizes = nt_sizes.to(torch::kCUDA);
+
+  c10::Half* mean_ptr = mean.data_ptr<c10::Half>();
+  c10::Half* invstd_ptr = invstd.data_ptr<c10::Half>();
+  c10::Half* bias_ptr = bias_cont.data_ptr<c10::Half>();
+  c10::Half* weight_ptr = weight_cont.data_ptr<c10::Half>();
+
+  at::cuda::CUDAStream defaultStream = at::cuda::getDefaultCUDAStream();
+  nested_tensor::cuda::batchnorm_inference_kernelLauncher(
+      input_buffer.data_ptr<c10::Half>(),
+      mean_ptr,
+      invstd_ptr,
+      weight_ptr,
+      bias_ptr,
+      output_buffer.data_ptr<c10::Half>(),
+      (int)(*self_opt_sizes[0] * *self_opt_sizes[1]),
+      (int)(*self_opt_sizes[0]),
+      nt_sizes.data_ptr<int>(),
+      defaultStream
+      );
+  return wrap_buffer(std::move(output_buffer), get_efficient_nested_size(output), get_efficient_nested_stride(output));
+
+  // Tensor input_buffer = get_buffer(input);
+  // Tensor output_buffer 
+
+  // Tensor output = input;
+  // output = output - mean.reshape(IntArrayRef(scalar_shape));
+  // output = output * invstd.reshape(IntArrayRef(scalar_shape));
+
+  // if (weight) {
+  //   output = output * weight->reshape(IntArrayRef(scalar_shape));
+  // }
+  // if (bias) {
+  //   output = output + bias->reshape(IntArrayRef(scalar_shape));
+  // }
+  // return output;
 }
 
 TORCH_LIBRARY_IMPL(aten, NestedTensor, m) {

--- a/nestedtensor/csrc/autograd_functions.cpp
+++ b/nestedtensor/csrc/autograd_functions.cpp
@@ -124,6 +124,7 @@ Tensor NestedTensor_batch_norm(
 
   at::Tensor mean = *running_mean;
   at::Tensor var = *running_var;
+#ifdef WITH_CUDA
   if (weight &&
       bias &&
       (is_nested_tensor_impl(input)) &&
@@ -198,6 +199,7 @@ Tensor NestedTensor_batch_norm(
         );
     return wrap_buffer(std::move(output_buffer), get_efficient_nested_size(output), get_efficient_nested_stride(output));
   }
+#endif
 
   at::Tensor invstd = 1 / at::sqrt(*running_var + eps);
 

--- a/nestedtensor/csrc/autograd_functions.cpp
+++ b/nestedtensor/csrc/autograd_functions.cpp
@@ -106,22 +106,6 @@ Tensor NestedTensor_batch_norm(
   }
 
   auto scalar_shape = make_scalar_shape(get_dim(input), n_input);
-  // std::cout << "IntArrayRef(scalar_shape): " << IntArrayRef(scalar_shape) << std::endl;
-  // std::cout << "weight.has_value(): " << weight.has_value() << std::endl;
-  // std::cout << "bias.has_value(): " << bias.has_value() << std::endl;
-  // std::cout << "is_nested_tensor_impl(running_mean): " << is_nested_tensor_impl(*running_mean) << std::endl;
-  // std::cout << "is_nested_tensor_impl(running_var): " << is_nested_tensor_impl(*running_var) << std::endl;
-  // std::cout << "is_nested_tensor_impl(bias): " << is_nested_tensor_impl(*bias) << std::endl;
-  // std::cout << "is_nested_tensor_impl(weight): " << is_nested_tensor_impl(*weight) << std::endl;
-  // std::cout << "(running_mean): " << (*running_mean).sizes() << std::endl;
-  // std::cout << "(running_var): " << (*running_var).sizes() << std::endl;
-  // std::cout << "(bias): " << (*bias).sizes() << std::endl;
-  // std::cout << "(weight): " << (*weight).sizes() << std::endl;
-  // map([](std::vector<int64_t> size) {
-  //     std::cout << "IntArrayRef(size): " << IntArrayRef(size) << std::endl;
-  //     return size;
-  //     }, get_nested_size(input));
-
   at::Tensor mean = *running_mean;
   at::Tensor var = *running_var;
 #ifdef WITH_CUDA
@@ -165,16 +149,11 @@ Tensor NestedTensor_batch_norm(
     int64_t index = 1;
     for (int64_t i = 0; i < nt_sizes_all.size(0); i++) {
       for (int64_t j = 0; j < *self_opt_sizes[1]; j++) {
-        // numbers.push_back(nt_sizes_all_ptr[i]);
         numbers.push_back(numbers[index - 1] + nt_sizes_all_ptr[i]);
         index++;
       }
     }
     at::Tensor numbers_t = torch::tensor(numbers).to(torch::kInt32);
-    // Tensor nt_sizes_cumsum =
-    //     at::native::cumsum(numbers_t, 0).to(torch::kInt32).reshape({-1});
-    // TORCH_CHECK(nt_sizes_.dim() == 2, "NestedTensor metadata of unexpected dimension.")
-    // Tensor nt_sizes = at::cat({torch::tensor({0}, torch::kInt32), nt_sizes_cumsum});
     Tensor nt_sizes = numbers_t.to(torch::kCUDA);
   
     c10::Half* mean_ptr = mean.data_ptr<c10::Half>();
@@ -186,7 +165,6 @@ Tensor NestedTensor_batch_norm(
     nested_tensor::cuda::batchnorm_inference_kernelLauncher(
         input_buffer.data_ptr<c10::Half>(),
         mean_ptr,
-        // invstd_ptr,
         running_var_ptr,
         c10::Half((float)(eps)),
         weight_ptr,

--- a/nestedtensor/csrc/conv2d.cpp
+++ b/nestedtensor/csrc/conv2d.cpp
@@ -18,11 +18,16 @@ Tensor NestedTensor_conv2d(
     int64_t groups) {
   Tensor input = input_;
   if (is_nested_tensor_impl(input) && !is_nested_tensor_impl(weight)) {
+    // std::cout << "weight.sizes(): " << weight.sizes() << std::endl;
+    // std::cout << "stride: " << stride << std::endl;
+    // std::cout << "padding: " << padding << std::endl;
+    // std::cout << "dilation: " << dilation << std::endl;
+    // std::cout << "groups: " << groups << std::endl;
     if (get_dim(input) == 4 && !bias && weight.size(2) == 1 && weight.size(3) == 1 &&
         stride[0] == 1 && stride[1] == 1 &&
         padding[0] == 0 && padding[1] == 0 &&
         dilation[0] == 1 && dilation[1] == 1 &&
-        weight.size(0) == weight.size(1) &&
+        // weight.size(0) == weight.size(1) &&
         groups == 1
       ) {
       input = NestedTensor_contiguous(input);
@@ -41,6 +46,7 @@ Tensor NestedTensor_conv2d(
         result_splits.push_back(result_split_i.reshape(-1));
       }
       at::Tensor result_buffer = at::cat(result_splits);
+      // std::cout << "calling packed conv2d" << std::endl;
       return wrap_buffer(std::move(result_buffer), get_efficient_nested_size(input),
           get_efficient_nested_stride(input));
     }

--- a/nestedtensor/csrc/conv2d.cpp
+++ b/nestedtensor/csrc/conv2d.cpp
@@ -18,36 +18,98 @@ Tensor NestedTensor_conv2d(
     int64_t groups) {
   Tensor input = input_;
   if (is_nested_tensor_impl(input) && !is_nested_tensor_impl(weight)) {
-    if (!bias && weight.size(2) == 1 && weight.size(3) == 1 &&
+    if (get_dim(input) == 4 && !bias && weight.size(2) == 1 && weight.size(3) == 1 &&
         stride[0] == 1 && stride[1] == 1 &&
         padding[0] == 0 && padding[1] == 0 &&
         dilation[0] == 1 && dilation[1] == 1 &&
         groups == 1
       ) {
       input = NestedTensor_contiguous(input);
-      auto input_opt_sizes = get_opt_sizes(input);
-      at::Tensor input_buffer = get_buffer(input);
+      auto unbound_input = at::unbind(input, 0);
+      std::vector<at::Tensor> unfolded_input;
+      std::vector<at::Tensor> result_splits;
       at::Tensor weight_view = weight.view({weight.size(0), -1});
-      std::cout << "orig input_buffer: " << input_buffer << std::endl;
-      input_buffer = input_buffer.reshape({1, 1, -1, weight_view.size(1)});
-      std::cout << "input_buffer.sizes(): " << input_buffer.sizes() << std::endl;
-      std::cout << "input_buffer: " << input_buffer << std::endl;
-      at::Tensor result = at::matmul(input_buffer, weight_view.transpose(0, 1));
-      std::cout << 
-        "at::matmul(input_buffer, weight_view.transpose(0, 1)): " <<
-        result <<
-        std::endl;
-      auto ef_size = get_efficient_nested_size(input);
-      auto ef_stride = get_efficient_nested_stride(input);
-      auto out_size = map_efficient_size(
-          [&weight](int64_t* size_ptr, int64_t size_size) {
-          size_ptr[0] = weight.size(0);
-          for  (int64_t i = 0; i < size_size; i++) {
-          std::cout << size_ptr[i] << std::endl;
-          }
-          }, ef_size);
-      return wrap_buffer(result.reshape(-1), 
-          out_size, out_stride);
+      weight_view = weight_view.transpose(0, 1);
+      for(size_t i = 0; i < unbound_input.size(); i++) {
+        // std::cout << "unbound_input[" << i << "]: " << unbound_input[i] << std::endl;
+        at::Tensor unfolded_split_i =  torch::im2col(unbound_input[i].unsqueeze(0),
+                                                  {weight.size(2), weight.size(3)},
+                                                  {1, 1}, {0, 0}, {1, 1});
+        unfolded_split_i = unfolded_split_i.transpose(1, 2);
+        unfolded_input.push_back(unfolded_split_i);
+        // std::cout << "unfolded_split_i[" << i << "]: " << unfolded_split_i << std::endl;
+        at::Tensor result_split_i = at::matmul(unfolded_split_i, weight_view).transpose(1, 2);
+        // std::cout << "result_split_" << i << ": " << result_split_i << std::endl;
+        result_splits.push_back(result_split_i.reshape(-1));
+      }
+      // at::Tensor catted_input = at::cat(unfolded_input, 1);
+      // // std::cout << "catted_input: " << catted_input << std::endl;
+      // at::Tensor composite_result_buffer = at::matmul(catted_input, weight_view).transpose(1, 2);
+      // std::cout << "composite_result_buffer: " << composite_result_buffer << std::endl;
+      // std::cout << "composite_result_buffer.reshape(-1): " << composite_result_buffer.reshape(-1) << std::endl;
+      // std::cout << "composite_result_buffer.contiguous().reshape(-1): " << composite_result_buffer.contiguous().reshape(-1) << std::endl;
+      at::Tensor result_buffer = at::cat(result_splits);
+      // std::cout << "result_buffer: " << result_buffer << std::endl;
+      return wrap_buffer(std::move(result_buffer), get_efficient_nested_size(input),
+          get_efficient_nested_stride(input));
+      // return wrap_buffer(composite_result_buffer.reshape(-1), get_efficient_nested_size(input),
+      //     get_efficient_nested_stride(input));
+
+      // // auto input_opt_sizes = get_opt_sizes(input);
+      // // at::Tensor input_buffer = get_buffer(input);
+      // // at::Tensor weight_view = weight.view({weight.size(0), -1});
+      // // std::cout << "orig input_buffer: " << input_buffer << std::endl;
+      // // input_buffer = input_buffer.reshape({1, 1, -1, weight_view.size(1)});
+      // // std::cout << "input_buffer.sizes(): " << input_buffer.sizes() << std::endl;
+      // // std::cout << "input_buffer: " << input_buffer << std::endl;
+      // // at::Tensor result = at::matmul(input_buffer, weight_view.transpose(0, 1));
+      // // std::cout << 
+      // //   "at::matmul(input_buffer, weight_view.transpose(0, 1)): " <<
+      // //   result <<
+      // //   std::endl;
+      // // auto ef_size = get_efficient_nested_size(input).sizes();
+      // // auto ef_stride = get_efficient_nested_stride(input);
+      // // std::cout << "ef_size: " << ef_size << std::endl;
+      // // Tensor ef_size0 = at::native::narrow(ef_size, 1, 0, 1);
+      // // Tensor ef_size1 = at::native::narrow(ef_size, 1, 1, 1);
+      // // Tensor ef_size2 = at::native::narrow(ef_size, 1, 2, 1);
+      // // Tensor ef_sizeall = ef_size0 * ef_size1 * ef_size2;
+      // // std::cout << "ef_sizeall: " << ef_sizeall << std::endl;
+      // // std::vector<int64_t> ef_splits;
+      // // for (int64_t i = 0; i < ef_sizeall.size(0); i++) {
+      // //   ef_splits.push_back(ef_sizeall[i].item<int64_t>());
+      // // }
+      // // std::vector<at::Tensor> splits = at::split_with_sizes(input_buffer.reshape({-1}), ef_splits);
+      // // std::vector<at::Tensor> unfolded_splits;
+      // // for (size_t i = 0; i < splits.size(); i++) {
+      // //   splits[i] = splits[i].reshape({-1, weight.size(1), ef_size1[i].item<int64_t>(), ef_size2[i].item<int64_t>()});
+      // //   std::cout << "splits[" << i << "]" << splits[i] << std::endl;
+      // //   at::Tensor unfolded_split_i =  torch::im2col(splits[i], {weight.size(2), weight.size(3)},
+      // //                                               {1, 1}, {0, 0}, {1, 1});
+      // //   std::cout << "unfolded_split_" << i << ": " << unfolded_split_i << std::endl;
+      // //   unfolded_splits.push_back(unfolded_split_i);
+      // // }
+      // // at::Tensor unfolded_input = at::cat(unfolded_splits, 2);
+      // // std::cout << "unfolded_input: " << unfolded_input << std::endl;
+      // // std::cout << "unfolded_input.transpose(1, 2): " << unfolded_input.transpose(1, 2) << std::endl;
+      // // at::Tensor result_buffer = at::matmul(unfolded_input.transpose(1, 2), weight.reshape({-1, weight.size(1)}));
+      // // std::cout << "result_buffer: " << result_buffer << std::endl;
+      // // result_buffer = result_buffer.contiguous();
+      // // std::vector<at::Tensor> result_splits = at::split_with_sizes(result_buffer.reshape({-1}), ef_splits);
+      // // for (size_t i = 0; i < splits.size(); i++) {
+      // //   result_splits[i] = result_splits[i].reshape(-1);
+      // //   std::cout << "result_splits[" << i << "]: " << result_splits[i] << std::endl;
+      // // }
+      // // at::Tensor cat_splits = at::cat(result_splits);
+      // // cat_splits = cat_splits.reshape({weight.size(1), -1}).transpose(0, 1).contiguous();
+      // // return wrap_buffer(cat_splits.reshape(-1), get_efficient_nested_size(input),
+      // //     get_efficient_nested_stride(input));
+      // std::cout << "result_buffer: " << result_buffer << std::endl;
+      // std::cout << "unfolded_input.sizes(): " << unfolded_input.sizes() << std::endl;
+      // at::Tensor folded_result_buffer = at::col2im(result_buffer, {5, 16}, {1, 1}, {1, 1}, {0, 0}, {1, 1});
+      // std::cout << "folded_result_buffer: " << folded_result_buffer << std::endl;
+      // return wrap_buffer(result.reshape(-1), 
+      //     ef_size, ef_stride);
 
       // std::cout << 
       // "at::conv2d(input_buffer, weight, bias, stride, padding, dilation, groups): " <<

--- a/nestedtensor/csrc/conv2d.cpp
+++ b/nestedtensor/csrc/conv2d.cpp
@@ -41,16 +41,10 @@ Tensor NestedTensor_conv2d(
       return result;
     }
   }
-    // std::cout << "weight.sizes(): " << weight.sizes() << std::endl;
-    // std::cout << "stride: " << stride << std::endl;
-    // std::cout << "padding: " << padding << std::endl;
-    // std::cout << "dilation: " << dilation << std::endl;
-    // std::cout << "groups: " << groups << std::endl;
   if (bias) {
       return map_nested_tensor(
           [&stride, &padding, &dilation, &groups](at::Tensor input, at::Tensor weight, at::Tensor bias) {
             return at::conv2d(input.unsqueeze(0), weight, bias, stride, padding, dilation, groups).squeeze(0);
-            // return at::conv2d(input, self, c10::nullopt, stride, padding, dilation, groups);
           },
           input,
           weight,
@@ -59,7 +53,6 @@ Tensor NestedTensor_conv2d(
   return map_nested_tensor(
       [&stride, &padding, &dilation, &groups](at::Tensor input, at::Tensor weight) {
         return at::conv2d(input.unsqueeze(0), weight, c10::nullopt, stride, padding, dilation, groups).squeeze(0);
-        // return at::conv2d(input, self, c10::nullopt, stride, padding, dilation, groups);
       },
       input,
       weight);

--- a/nestedtensor/csrc/conv2d.cpp
+++ b/nestedtensor/csrc/conv2d.cpp
@@ -36,10 +36,6 @@ Tensor NestedTensor_conv2d(
           }, get_efficient_nested_size(input));
       at::Tensor result = wrap_buffer(result_buffer.reshape(-1),
           new_sizes);
-          // map([&weight](std::vector<int64_t> size) {
-          // size[2] = weight.size(0);
-          // return size;
-          // }, get_nested_size(input)));
       result = result.transpose(1, 3);
       result = NestedTensor_contiguous(result);
       return result;

--- a/nestedtensor/csrc/conv2d.cpp
+++ b/nestedtensor/csrc/conv2d.cpp
@@ -30,11 +30,16 @@ Tensor NestedTensor_conv2d(
       input_buffer = input_buffer.reshape({-1, weight.size(1)});
       at::Tensor result_buffer = at::matmul(input_buffer, 
           weight.reshape({weight.size(0), weight.size(1)}).transpose(0, 1));
+      int64_t weight_size_0 = weight.size(0);
+      auto new_sizes = map_efficient_size([&weight_size_0](int64_t* size_ptr, int64_t size) {
+          size_ptr[2] = weight_size_0;
+          }, get_efficient_nested_size(input));
       at::Tensor result = wrap_buffer(result_buffer.reshape(-1),
-          map([&weight](std::vector<int64_t> size) {
-          size[2] = weight.size(0);
-          return size;
-          }, get_nested_size(input)));
+          new_sizes);
+          // map([&weight](std::vector<int64_t> size) {
+          // size[2] = weight.size(0);
+          // return size;
+          // }, get_nested_size(input)));
       result = result.transpose(1, 3);
       result = NestedTensor_contiguous(result);
       return result;

--- a/nestedtensor/csrc/conv2d.cpp
+++ b/nestedtensor/csrc/conv2d.cpp
@@ -22,6 +22,7 @@ Tensor NestedTensor_conv2d(
         stride[0] == 1 && stride[1] == 1 &&
         padding[0] == 0 && padding[1] == 0 &&
         dilation[0] == 1 && dilation[1] == 1 &&
+        weight.size(0) == weight.size(1) &&
         groups == 1
       ) {
       input = NestedTensor_contiguous(input);
@@ -31,108 +32,17 @@ Tensor NestedTensor_conv2d(
       at::Tensor weight_view = weight.view({weight.size(0), -1});
       weight_view = weight_view.transpose(0, 1);
       for(size_t i = 0; i < unbound_input.size(); i++) {
-        // std::cout << "unbound_input[" << i << "]: " << unbound_input[i] << std::endl;
         at::Tensor unfolded_split_i =  torch::im2col(unbound_input[i].unsqueeze(0),
                                                   {weight.size(2), weight.size(3)},
                                                   {1, 1}, {0, 0}, {1, 1});
         unfolded_split_i = unfolded_split_i.transpose(1, 2);
         unfolded_input.push_back(unfolded_split_i);
-        // std::cout << "unfolded_split_i[" << i << "]: " << unfolded_split_i << std::endl;
         at::Tensor result_split_i = at::matmul(unfolded_split_i, weight_view).transpose(1, 2);
-        // std::cout << "result_split_" << i << ": " << result_split_i << std::endl;
         result_splits.push_back(result_split_i.reshape(-1));
       }
-      // at::Tensor catted_input = at::cat(unfolded_input, 1);
-      // // std::cout << "catted_input: " << catted_input << std::endl;
-      // at::Tensor composite_result_buffer = at::matmul(catted_input, weight_view).transpose(1, 2);
-      // std::cout << "composite_result_buffer: " << composite_result_buffer << std::endl;
-      // std::cout << "composite_result_buffer.reshape(-1): " << composite_result_buffer.reshape(-1) << std::endl;
-      // std::cout << "composite_result_buffer.contiguous().reshape(-1): " << composite_result_buffer.contiguous().reshape(-1) << std::endl;
       at::Tensor result_buffer = at::cat(result_splits);
-      // std::cout << "result_buffer: " << result_buffer << std::endl;
       return wrap_buffer(std::move(result_buffer), get_efficient_nested_size(input),
           get_efficient_nested_stride(input));
-      // return wrap_buffer(composite_result_buffer.reshape(-1), get_efficient_nested_size(input),
-      //     get_efficient_nested_stride(input));
-
-      // // auto input_opt_sizes = get_opt_sizes(input);
-      // // at::Tensor input_buffer = get_buffer(input);
-      // // at::Tensor weight_view = weight.view({weight.size(0), -1});
-      // // std::cout << "orig input_buffer: " << input_buffer << std::endl;
-      // // input_buffer = input_buffer.reshape({1, 1, -1, weight_view.size(1)});
-      // // std::cout << "input_buffer.sizes(): " << input_buffer.sizes() << std::endl;
-      // // std::cout << "input_buffer: " << input_buffer << std::endl;
-      // // at::Tensor result = at::matmul(input_buffer, weight_view.transpose(0, 1));
-      // // std::cout << 
-      // //   "at::matmul(input_buffer, weight_view.transpose(0, 1)): " <<
-      // //   result <<
-      // //   std::endl;
-      // // auto ef_size = get_efficient_nested_size(input).sizes();
-      // // auto ef_stride = get_efficient_nested_stride(input);
-      // // std::cout << "ef_size: " << ef_size << std::endl;
-      // // Tensor ef_size0 = at::native::narrow(ef_size, 1, 0, 1);
-      // // Tensor ef_size1 = at::native::narrow(ef_size, 1, 1, 1);
-      // // Tensor ef_size2 = at::native::narrow(ef_size, 1, 2, 1);
-      // // Tensor ef_sizeall = ef_size0 * ef_size1 * ef_size2;
-      // // std::cout << "ef_sizeall: " << ef_sizeall << std::endl;
-      // // std::vector<int64_t> ef_splits;
-      // // for (int64_t i = 0; i < ef_sizeall.size(0); i++) {
-      // //   ef_splits.push_back(ef_sizeall[i].item<int64_t>());
-      // // }
-      // // std::vector<at::Tensor> splits = at::split_with_sizes(input_buffer.reshape({-1}), ef_splits);
-      // // std::vector<at::Tensor> unfolded_splits;
-      // // for (size_t i = 0; i < splits.size(); i++) {
-      // //   splits[i] = splits[i].reshape({-1, weight.size(1), ef_size1[i].item<int64_t>(), ef_size2[i].item<int64_t>()});
-      // //   std::cout << "splits[" << i << "]" << splits[i] << std::endl;
-      // //   at::Tensor unfolded_split_i =  torch::im2col(splits[i], {weight.size(2), weight.size(3)},
-      // //                                               {1, 1}, {0, 0}, {1, 1});
-      // //   std::cout << "unfolded_split_" << i << ": " << unfolded_split_i << std::endl;
-      // //   unfolded_splits.push_back(unfolded_split_i);
-      // // }
-      // // at::Tensor unfolded_input = at::cat(unfolded_splits, 2);
-      // // std::cout << "unfolded_input: " << unfolded_input << std::endl;
-      // // std::cout << "unfolded_input.transpose(1, 2): " << unfolded_input.transpose(1, 2) << std::endl;
-      // // at::Tensor result_buffer = at::matmul(unfolded_input.transpose(1, 2), weight.reshape({-1, weight.size(1)}));
-      // // std::cout << "result_buffer: " << result_buffer << std::endl;
-      // // result_buffer = result_buffer.contiguous();
-      // // std::vector<at::Tensor> result_splits = at::split_with_sizes(result_buffer.reshape({-1}), ef_splits);
-      // // for (size_t i = 0; i < splits.size(); i++) {
-      // //   result_splits[i] = result_splits[i].reshape(-1);
-      // //   std::cout << "result_splits[" << i << "]: " << result_splits[i] << std::endl;
-      // // }
-      // // at::Tensor cat_splits = at::cat(result_splits);
-      // // cat_splits = cat_splits.reshape({weight.size(1), -1}).transpose(0, 1).contiguous();
-      // // return wrap_buffer(cat_splits.reshape(-1), get_efficient_nested_size(input),
-      // //     get_efficient_nested_stride(input));
-      // std::cout << "result_buffer: " << result_buffer << std::endl;
-      // std::cout << "unfolded_input.sizes(): " << unfolded_input.sizes() << std::endl;
-      // at::Tensor folded_result_buffer = at::col2im(result_buffer, {5, 16}, {1, 1}, {1, 1}, {0, 0}, {1, 1});
-      // std::cout << "folded_result_buffer: " << folded_result_buffer << std::endl;
-      // return wrap_buffer(result.reshape(-1), 
-      //     ef_size, ef_stride);
-
-      // std::cout << 
-      // "at::conv2d(input_buffer, weight, bias, stride, padding, dilation, groups): " <<
-      // at::conv2d(input_buffer, weight.view(1, -1), bias, stride, padding, dilation, groups) <<
-      // std::endl;
-      // std::cout << 
-      //   "torch::im2col(input_buffer, {weight.size(0), weight.size(1)}): " <<
-      //   torch::im2col(input_buffer, {weight.size(2), weight.size(3)},
-      //       {1, 1}, {0, 0}, {1, 1}) << std::endl;
-      // std::cout << "input_buffer.reshape({-1, weight_view.size(0)}): " <<
-      //   input_buffer.reshape({1, -1, weight_view.size(1)}).transpose(1, 2) << std::endl;
-      // std::cout << "weight: " << weight << std::endl;
-      // std::cout << "weight_view: " << weight_view << std::endl;
-      // std::cout << "bias.has_value(): " << bias.has_value() << std::endl;
-      // std::cout << "is_nested_tensor_impl(input): " << is_nested_tensor_impl(input) << std::endl;
-      // std::cout << "is_nested_tensor_impl(weight): " << is_nested_tensor_impl(weight) << std::endl;
-      // std::cout << "weight.sizes(): " << weight.sizes() << std::endl;
-      // std::cout << "stride: " << stride << std::endl;
-      // std::cout << "padding: " << padding << std::endl;
-      // std::cout << "dilation: " << dilation << std::endl;
-      // std::cout << "groups: " << groups << std::endl;
-      // at::Tensor result = at::matmul(weight_view, input_buffer.reshape({1, -1, weight_view.size(1)}).transpose(1, 2));
-      // std::cout << "result: " << result << std::endl;
     }
   }
   if (bias) {

--- a/nestedtensor/csrc/conv2d.cpp
+++ b/nestedtensor/csrc/conv2d.cpp
@@ -9,22 +9,79 @@ namespace F = torch::nn::functional;
 namespace at {
 
 Tensor NestedTensor_conv2d(
-    const Tensor& input,
+    const Tensor& input_,
     const Tensor& weight,
     const c10::optional<Tensor>& bias,
     IntArrayRef stride,
     IntArrayRef padding,
     IntArrayRef dilation,
     int64_t groups) {
+  Tensor input = input_;
+  if (is_nested_tensor_impl(input) && !is_nested_tensor_impl(weight)) {
+    if (!bias && weight.size(2) == 1 && weight.size(3) == 1 &&
+        stride[0] == 1 && stride[1] == 1 &&
+        padding[0] == 0 && padding[1] == 0 &&
+        dilation[0] == 1 && dilation[1] == 1 &&
+        groups == 1
+      ) {
+      input = NestedTensor_contiguous(input);
+      auto input_opt_sizes = get_opt_sizes(input);
+      at::Tensor input_buffer = get_buffer(input);
+      at::Tensor weight_view = weight.view({weight.size(0), -1});
+      std::cout << "orig input_buffer: " << input_buffer << std::endl;
+      input_buffer = input_buffer.reshape({1, 1, -1, weight_view.size(1)});
+      std::cout << "input_buffer.sizes(): " << input_buffer.sizes() << std::endl;
+      std::cout << "input_buffer: " << input_buffer << std::endl;
+      at::Tensor result = at::matmul(input_buffer, weight_view.transpose(0, 1));
+      std::cout << 
+        "at::matmul(input_buffer, weight_view.transpose(0, 1)): " <<
+        result <<
+        std::endl;
+      auto ef_size = get_efficient_nested_size(input);
+      auto ef_stride = get_efficient_nested_stride(input);
+      auto out_size = map_efficient_size(
+          [&weight](int64_t* size_ptr, int64_t size_size) {
+          size_ptr[0] = weight.size(0);
+          for  (int64_t i = 0; i < size_size; i++) {
+          std::cout << size_ptr[i] << std::endl;
+          }
+          }, ef_size);
+      return wrap_buffer(result.reshape(-1), 
+          out_size, out_stride);
+
+      // std::cout << 
+      // "at::conv2d(input_buffer, weight, bias, stride, padding, dilation, groups): " <<
+      // at::conv2d(input_buffer, weight.view(1, -1), bias, stride, padding, dilation, groups) <<
+      // std::endl;
+      // std::cout << 
+      //   "torch::im2col(input_buffer, {weight.size(0), weight.size(1)}): " <<
+      //   torch::im2col(input_buffer, {weight.size(2), weight.size(3)},
+      //       {1, 1}, {0, 0}, {1, 1}) << std::endl;
+      // std::cout << "input_buffer.reshape({-1, weight_view.size(0)}): " <<
+      //   input_buffer.reshape({1, -1, weight_view.size(1)}).transpose(1, 2) << std::endl;
+      // std::cout << "weight: " << weight << std::endl;
+      // std::cout << "weight_view: " << weight_view << std::endl;
+      // std::cout << "bias.has_value(): " << bias.has_value() << std::endl;
+      // std::cout << "is_nested_tensor_impl(input): " << is_nested_tensor_impl(input) << std::endl;
+      // std::cout << "is_nested_tensor_impl(weight): " << is_nested_tensor_impl(weight) << std::endl;
+      // std::cout << "weight.sizes(): " << weight.sizes() << std::endl;
+      // std::cout << "stride: " << stride << std::endl;
+      // std::cout << "padding: " << padding << std::endl;
+      // std::cout << "dilation: " << dilation << std::endl;
+      // std::cout << "groups: " << groups << std::endl;
+      // at::Tensor result = at::matmul(weight_view, input_buffer.reshape({1, -1, weight_view.size(1)}).transpose(1, 2));
+      // std::cout << "result: " << result << std::endl;
+    }
+  }
   if (bias) {
-  return map_nested_tensor(
-      [&stride, &padding, &dilation, &groups](at::Tensor input, at::Tensor weight, at::Tensor bias) {
-        return at::conv2d(input.unsqueeze(0), weight, bias, stride, padding, dilation, groups).squeeze(0);
-        // return at::conv2d(input, self, c10::nullopt, stride, padding, dilation, groups);
-      },
-      input,
-      weight,
-      *bias);
+      return map_nested_tensor(
+          [&stride, &padding, &dilation, &groups](at::Tensor input, at::Tensor weight, at::Tensor bias) {
+            return at::conv2d(input.unsqueeze(0), weight, bias, stride, padding, dilation, groups).squeeze(0);
+            // return at::conv2d(input, self, c10::nullopt, stride, padding, dilation, groups);
+          },
+          input,
+          weight,
+          *bias);
   }
   return map_nested_tensor(
       [&stride, &padding, &dilation, &groups](at::Tensor input, at::Tensor weight) {

--- a/nestedtensor/csrc/cuda/add.cu
+++ b/nestedtensor/csrc/cuda/add.cu
@@ -1,0 +1,64 @@
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cmath>
+#include <nestedtensor/csrc/cuda/attention.h>
+#include <stdio.h>
+
+namespace nested_tensor {
+namespace cuda {
+
+template<typename T>
+__global__
+void add_scalars(
+    const T* input,
+    const T* scalars,
+    T* output,
+    const int* offsets)
+{
+  const int batch_id  = blockIdx.x;
+  const int grain_size = blockDim.x;
+  const int tid = threadIdx.x;
+  const int range = (offsets[batch_id + 1] - offsets[batch_id]) * inner_size;
+  const int num_chunks = range / grain_size;
+  for (int id = 0; id < num_chunks; id++) {
+    output[batch_id * output_stride + id * grain_size + tid]
+      = input[offsets[batch_id] * inner_size + id * grain_size + tid] + scalars[batch_id];
+  }
+  const int leftover = num_chunks * grain_size;
+  if (leftover + tid < range) {
+    output[batch_id * output_stride + leftover + tid]
+      = input[offsets[batch_id] * inner_size + leftover + tid] + scalars[batch_id];
+  }
+}
+
+void add_padding_kernelLauncher(
+    T* input, // [batch_size x None]
+    T* output, // [batch_size x max(input.nested_size(1)) x inner_size]
+    const int* offsets, // [batch_size]
+    const int batch_size,
+    const int output_stride,
+    const int inner_size,
+    const cudaStream_t stream)
+{
+  dim3 grid;
+  grid.x = batch_size;
+
+  add_padding<float><<<grid, 1024, 0, stream>>>(
+      input,
+      output,
+      offsets,
+      batch_size,
+      output_stride,
+      inner_size);
+}
+
+template void add_padding_kernelLauncher<float>(
+    float* input,
+    float* output,
+    const int* offsets,
+    const int batch_size,
+    const int output_stride,
+    const int inner_size,
+    const cudaStream_t stream);
+}
+}

--- a/nestedtensor/csrc/cuda/add.cu
+++ b/nestedtensor/csrc/cuda/add.cu
@@ -7,58 +7,92 @@
 namespace nested_tensor {
 namespace cuda {
 
-template<typename T>
 __global__
 void add_scalars(
-    const T* input,
-    const T* scalars,
-    T* output,
+    const __half* input,
+    const __half* scalars,
+    __half* output,
+    const int input_outer_stride,
     const int* offsets)
 {
   const int batch_id  = blockIdx.x;
-  const int grain_size = blockDim.x;
+  const int scalars_id  = batch_id / input_outer_stride;
+  // const int grain_size = blockDim.x;
   const int tid = threadIdx.x;
-  const int range = (offsets[batch_id + 1] - offsets[batch_id]) * inner_size;
-  const int num_chunks = range / grain_size;
-  for (int id = 0; id < num_chunks; id++) {
-    output[batch_id * output_stride + id * grain_size + tid]
-      = input[offsets[batch_id] * inner_size + id * grain_size + tid] + scalars[batch_id];
+  const int range = (offsets[batch_id + 1] - offsets[batch_id]);
+  // const int num_chunks = range / grain_size;
+  // printf("scalars_id: %d\n", scalars_id);
+  // // printf("batch_id: %d , input_outer_stride: %d , scalars_id: %d\n",
+  // //     batch_id, input_outer_stride, scalars_id);
+  for (int id = offsets[batch_id]; id < offsets[batch_id + 1]; id++) {
+    // printf("id: %d , tid: %d\n", id, tid);
+    output[id] = __hadd(input[id], scalars[scalars_id]);
   }
-  const int leftover = num_chunks * grain_size;
-  if (leftover + tid < range) {
-    output[batch_id * output_stride + leftover + tid]
-      = input[offsets[batch_id] * inner_size + leftover + tid] + scalars[batch_id];
+  // const int leftover = num_chunks * grain_size;
+  // if (leftover + tid < range) {
+  //   output[offsets[batch_id] + leftover + tid]
+  //     = input[offsets[batch_id] + leftover + tid];
+  //     // = __hadd(input[offsets[batch_id] + leftover + tid], scalars[scalars_id]);
+  // }
+}
+
+void add_scalar_kernelLauncher(
+    __half* input, // [batch_size x offsets[-1]]
+    __half* scalars, // [batch_size]
+    __half* output, // [batch_size x offsets[-1]]
+    const int batch_size,
+    const int input_outer_stride,
+    const int* offsets /* [batch_size] */,
+    const cudaStream_t stream)
+{
+  dim3 grid;
+  grid.x = batch_size;
+  // printf("batch_size: %d\n", batch_size);
+
+  add_scalars<<<grid, 1, 0, stream>>>(
+      input,
+      scalars,
+      output,
+      input_outer_stride,
+      offsets);
+}
+
+__global__
+void mul_scalars(
+    const __half* input,
+    const __half* scalars,
+    __half* output,
+    const int input_outer_stride,
+    const int* offsets)
+{
+  const int batch_id  = blockIdx.x;
+  const int scalars_id  = batch_id / input_outer_stride;
+  const int tid = threadIdx.x;
+  const int range = (offsets[batch_id + 1] - offsets[batch_id]);
+  for (int id = offsets[batch_id]; id < offsets[batch_id + 1]; id++) {
+    output[id] = __hmul(input[id], scalars[scalars_id]);
   }
 }
 
-void add_padding_kernelLauncher(
-    T* input, // [batch_size x None]
-    T* output, // [batch_size x max(input.nested_size(1)) x inner_size]
-    const int* offsets, // [batch_size]
+void mul_scalar_kernelLauncher(
+    __half* input, // [batch_size x offsets[-1]]
+    __half* scalars, // [batch_size]
+    __half* output, // [batch_size x offsets[-1]]
     const int batch_size,
-    const int output_stride,
-    const int inner_size,
+    const int input_outer_stride,
+    const int* offsets /* [batch_size] */,
     const cudaStream_t stream)
 {
   dim3 grid;
   grid.x = batch_size;
 
-  add_padding<float><<<grid, 1024, 0, stream>>>(
+  mul_scalars<<<grid, 1, 0, stream>>>(
       input,
+      scalars,
       output,
-      offsets,
-      batch_size,
-      output_stride,
-      inner_size);
+      input_outer_stride,
+      offsets);
 }
 
-template void add_padding_kernelLauncher<float>(
-    float* input,
-    float* output,
-    const int* offsets,
-    const int batch_size,
-    const int output_stride,
-    const int inner_size,
-    const cudaStream_t stream);
 }
 }

--- a/nestedtensor/csrc/cuda/add.cu
+++ b/nestedtensor/csrc/cuda/add.cu
@@ -23,13 +23,11 @@ void add_scalars(
   const int num_chunks = range / grain_size;
   for (int id = 0; id < num_chunks; id++) {
     output[offsets[batch_id] + id * grain_size + tid] =
-      // __hadd(input[offsets[batch_id] + id * grain_size + tid], scalars[scalars_id]);
       input[offsets[batch_id] + id * grain_size + tid] + scalars[scalars_id];
   }
   const int leftover = num_chunks * grain_size;
   if (leftover + tid < range) {
     output[offsets[batch_id] + leftover + tid] =
-      // __hadd(input[offsets[batch_id] + leftover + tid], scalars[scalars_id]);
       input[offsets[batch_id] + leftover + tid] + scalars[scalars_id];
   }
 }
@@ -45,7 +43,6 @@ void add_scalar_kernelLauncher(
 {
   dim3 grid;
   grid.x = batch_size;
-  // printf("batch_size: %d\n", batch_size);
 
   add_scalars<<<grid, 256, 0, stream>>>(
       input,
@@ -71,13 +68,11 @@ void mul_scalars(
   const int num_chunks = range / grain_size;
   for (int id = 0; id < num_chunks; id++) {
     output[offsets[batch_id] + id * grain_size + tid] =
-      // __hmul(input[offsets[batch_id] + id * grain_size + tid], scalars[scalars_id]);
       input[offsets[batch_id] + id * grain_size + tid] * scalars[scalars_id];
   }
   const int leftover = num_chunks * grain_size;
   if (leftover + tid < range) {
     output[offsets[batch_id] + leftover + tid] =
-      // __hmul(input[offsets[batch_id] + leftover + tid], scalars[scalars_id]);
       input[offsets[batch_id] + leftover + tid] * scalars[scalars_id];
   }
 }
@@ -151,7 +146,6 @@ __global__
 void batchnorm_inference(
     c10::Half* input,
     c10::Half* mean,
-    // c10::Half* invstd,
     c10::Half* running_var,
     c10::Half eps,
     c10::Half* weight,
@@ -166,7 +160,6 @@ void batchnorm_inference(
   const int tid = threadIdx.x;
   const int range = (offsets[batch_id + 1] - offsets[batch_id]);
   const int num_chunks = range / grain_size;
-  // c10::Half value = invstd[scalars_id] * weight[scalars_id];
   c10::Half value = running_var[scalars_id] + eps;
   value = hrsqrt(value);
   value = value * weight[scalars_id];
@@ -188,7 +181,6 @@ void batchnorm_inference(
 void batchnorm_inference_kernelLauncher(
     c10::Half* input, // [batch_size x offsets[-1]]
     c10::Half* mean, // [batch_size]
-    // c10::Half* invstd, // [batch_size]
     c10::Half* running_var,
     c10::Half eps,
     c10::Half* weight, // [batch_size]
@@ -205,7 +197,6 @@ void batchnorm_inference_kernelLauncher(
   batchnorm_inference<<<grid, 256, 0, stream>>>(
       input,
       mean,
-      // invstd,
       running_var,
       eps,
       weight,

--- a/nestedtensor/csrc/cuda/add.cu
+++ b/nestedtensor/csrc/cuda/add.cu
@@ -147,5 +147,65 @@ void sub_scalar_kernelLauncher(
       offsets);
 }
 
+__global__
+void batchnorm_inference(
+    c10::Half* input,
+    c10::Half* mean,
+    c10::Half* invstd,
+    c10::Half* weight,
+    c10::Half* bias,
+    c10::Half* output,
+    const int input_outer_stride,
+    const int* offsets)
+{
+  const int batch_id  = blockIdx.x;
+  const int scalars_id  = batch_id / input_outer_stride;
+  const int grain_size = blockDim.x;
+  const int tid = threadIdx.x;
+  const int range = (offsets[batch_id + 1] - offsets[batch_id]);
+  const int num_chunks = range / grain_size;
+  for (int id = 0; id < num_chunks; id++) {
+    output[offsets[batch_id] + id * grain_size + tid] =
+      ((((input[offsets[batch_id] + id * grain_size + tid] - mean[scalars_id])
+       * invstd[scalars_id])
+       * weight[scalars_id])
+       + bias[scalars_id]);
+  }
+  const int leftover = num_chunks * grain_size;
+  if (leftover + tid < range) {
+    output[offsets[batch_id] + leftover + tid] =
+      ((((input[offsets[batch_id] + leftover + tid] - mean[scalars_id])
+       * invstd[scalars_id])
+       * weight[scalars_id])
+       + bias[scalars_id]);
+  }
+}
+
+void batchnorm_inference_kernelLauncher(
+    c10::Half* input, // [batch_size x offsets[-1]]
+    c10::Half* mean, // [batch_size]
+    c10::Half* invstd, // [batch_size]
+    c10::Half* weight, // [batch_size]
+    c10::Half* bias, // [batch_size]
+    c10::Half* output, // [batch_size x offsets[-1]]
+    const int batch_size,
+    const int input_outer_stride,
+    const int* offsets /* [batch_size] */,
+    const cudaStream_t stream)
+{
+  dim3 grid;
+  grid.x = batch_size;
+
+  batchnorm_inference<<<grid, 16, 0, stream>>>(
+      input,
+      mean,
+      invstd,
+      weight,
+      bias,
+      output,
+      input_outer_stride,
+      offsets);
+}
+
 }
 }

--- a/nestedtensor/csrc/cuda/add.h
+++ b/nestedtensor/csrc/cuda/add.h
@@ -37,7 +37,9 @@ void sub_scalar_kernelLauncher(
 void batchnorm_inference_kernelLauncher(
     c10::Half* input,
     c10::Half* mean,
-    c10::Half* invstd,
+    // c10::Half* invstd,
+    c10::Half* running_var,
+    c10::Half eps,
     c10::Half* weight,
     c10::Half* bias,
     c10::Half* output,

--- a/nestedtensor/csrc/cuda/add.h
+++ b/nestedtensor/csrc/cuda/add.h
@@ -1,0 +1,20 @@
+
+#pragma once
+
+#include <assert.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+namespace nested_tensor {
+namespace cuda {
+
+template <typename T>
+void add_padding_kernelLauncher(
+    T* input,
+    T* output,
+    const int* lengths,
+    const int batch_size,
+    const int output_stride,
+    const int inner_size,
+    const cudaStream_t stream);
+}
+}

--- a/nestedtensor/csrc/cuda/add.h
+++ b/nestedtensor/csrc/cuda/add.h
@@ -8,18 +8,27 @@ namespace nested_tensor {
 namespace cuda {
 
 void add_scalar_kernelLauncher(
-    __half* input,
-    __half* scalars,
-    __half* output,
+    c10::Half* input,
+    c10::Half* scalars,
+    c10::Half* output,
     const int batch_size,
     const int input_outer_stride,
     const int* offsets,
     const cudaStream_t stream);
 
 void mul_scalar_kernelLauncher(
-    __half* input,
-    __half* scalars,
-    __half* output,
+    c10::Half* input,
+    c10::Half* scalars,
+    c10::Half* output,
+    const int batch_size,
+    const int input_outer_stride,
+    const int* offsets,
+    const cudaStream_t stream);
+
+void sub_scalar_kernelLauncher(
+    c10::Half* input,
+    c10::Half* scalars,
+    c10::Half* output,
     const int batch_size,
     const int input_outer_stride,
     const int* offsets,

--- a/nestedtensor/csrc/cuda/add.h
+++ b/nestedtensor/csrc/cuda/add.h
@@ -1,20 +1,29 @@
-
 #pragma once
-
 #include <assert.h>
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
+#include <c10/util/Half.h>
+
 namespace nested_tensor {
 namespace cuda {
 
-template <typename T>
-void add_padding_kernelLauncher(
-    T* input,
-    T* output,
-    const int* lengths,
+void add_scalar_kernelLauncher(
+    __half* input,
+    __half* scalars,
+    __half* output,
     const int batch_size,
-    const int output_stride,
-    const int inner_size,
+    const int input_outer_stride,
+    const int* offsets,
     const cudaStream_t stream);
+
+void mul_scalar_kernelLauncher(
+    __half* input,
+    __half* scalars,
+    __half* output,
+    const int batch_size,
+    const int input_outer_stride,
+    const int* offsets,
+    const cudaStream_t stream);
+
 }
 }

--- a/nestedtensor/csrc/cuda/add.h
+++ b/nestedtensor/csrc/cuda/add.h
@@ -34,5 +34,17 @@ void sub_scalar_kernelLauncher(
     const int* offsets,
     const cudaStream_t stream);
 
+void batchnorm_inference_kernelLauncher(
+    c10::Half* input,
+    c10::Half* mean,
+    c10::Half* invstd,
+    c10::Half* weight,
+    c10::Half* bias,
+    c10::Half* output,
+    const int batch_size,
+    const int input_outer_stride,
+    const int* offsets,
+    const cudaStream_t stream);
+
 }
 }

--- a/nestedtensor/csrc/masking.cpp
+++ b/nestedtensor/csrc/masking.cpp
@@ -218,7 +218,7 @@ std::tuple<Tensor, Tensor> to_tensor_mask(
     if (nt_opt_size[2] && nt_buffer.is_cuda()) {
       Tensor nt_sizes_ =
           get_efficient_nested_size(nt).sizes().to(torch::kInt32);
-      TORCH_CHECK(nt_sizes_.dim() == 2, "NestedTensor must be of nested_dim 2.")
+      TORCH_CHECK(nt_sizes_.dim() == 2, "NestedTensor metadata of unexpected dimension.")
       Tensor nt_sizes = at::native::narrow(nt_sizes_, 1, 0, 1);
       int max_size_1 = nt_sizes.max().item<int>();
       nt_sizes =

--- a/nestedtensor/csrc/nested_tensor_impl.cpp
+++ b/nestedtensor/csrc/nested_tensor_impl.cpp
@@ -107,6 +107,23 @@ at::Tensor wrap_buffer(
       std::shared_ptr<NestedTensorStorage>(ps_base));
 }
 
+at::Tensor wrap_buffer(
+    at::Tensor&& buffer,
+    EfficientSizeNode efficient_nested_size) {
+  TORCH_CHECK(buffer.is_contiguous(), "Given buffer must be contiguous.");
+  TORCH_CHECK(
+      efficient_nested_size.height() > 0,
+      "Internal error: expected nested_size of non-zero height.");
+  TORCH_CHECK(
+      efficient_nested_stride.height() > 0,
+      "Internal error: expected nested_size of non-zero height.");
+  PackedStorage* ps = new PackedStorage(
+      std::move(buffer), efficient_nested_size);
+  NestedTensorStorage* ps_base = dynamic_cast<NestedTensorStorage*>(ps);
+  return at::detail::make_tensor<NestedTensorImpl>(
+      std::shared_ptr<NestedTensorStorage>(ps_base));
+}
+
 Tensor NestedTensor_contiguous(const Tensor& self, MemoryFormat memory_format) {
   if (get_is_contiguous(self, memory_format)) {
     return self;

--- a/nestedtensor/csrc/nested_tensor_impl.cpp
+++ b/nestedtensor/csrc/nested_tensor_impl.cpp
@@ -34,7 +34,7 @@ NestedTensorImpl::NestedTensorImpl(std::shared_ptr<NestedTensorStorage> storage)
           storage->device()),
       _storage(storage) {
   remove_autograd_key();
-  key_set_ = key_set_ - c10::DispatchKeySet({DispatchKey::ADInplaceOrView});
+  key_set_ = key_set_ - c10::DispatchKeySet({c10::DispatchKey::ADInplaceOrView});
 }
 
 inline TensorNode _squeeze_nested_dim(TensorNode structure, int64_t dim) {

--- a/nestedtensor/csrc/nested_tensor_impl.cpp
+++ b/nestedtensor/csrc/nested_tensor_impl.cpp
@@ -114,9 +114,6 @@ at::Tensor wrap_buffer(
   TORCH_CHECK(
       efficient_nested_size.height() > 0,
       "Internal error: expected nested_size of non-zero height.");
-  TORCH_CHECK(
-      efficient_nested_stride.height() > 0,
-      "Internal error: expected nested_size of non-zero height.");
   PackedStorage* ps = new PackedStorage(
       std::move(buffer), efficient_nested_size);
   NestedTensorStorage* ps_base = dynamic_cast<NestedTensorStorage*>(ps);

--- a/nestedtensor/csrc/nested_tensor_impl.cpp
+++ b/nestedtensor/csrc/nested_tensor_impl.cpp
@@ -6,6 +6,7 @@
 #include <nestedtensor/csrc/utils/nested_node_functions.h>
 #include <torch/csrc/jit/runtime/operator.h>
 #include <torch/library.h>
+#include <c10/core/DispatchKey.h>
 
 namespace at {
 

--- a/nestedtensor/csrc/nested_tensor_impl.h
+++ b/nestedtensor/csrc/nested_tensor_impl.h
@@ -72,7 +72,7 @@ struct NestedTensorImpl : public c10::TensorImpl {
     return _storage;
   }
   int64_t nested_dim() const {
-    return 1;
+    return _storage->nested_size().height();
   }
   bool is_pinned() const {
     return _storage->is_pinned();
@@ -236,7 +236,7 @@ inline int64_t get_is_cuda(
 inline int64_t get_nested_dim(const at::Tensor& tensor) {
   TORCH_CHECK(
       is_nested_tensor_impl(tensor), "Given tensor must be NestedTensor.");
-  return 1;
+  return get_nested_tensor_impl(tensor)->nested_dim();
 }
 
 at::Tensor wrap_tensor_node(NestedTensorImpl);

--- a/nestedtensor/csrc/nested_tensor_impl.h
+++ b/nestedtensor/csrc/nested_tensor_impl.h
@@ -247,6 +247,9 @@ at::Tensor wrap_buffer(
     at::Tensor&&,
     EfficientSizeNode efficient_nested_size,
     EfficientSizeNode efficient_nested_stride);
+at::Tensor wrap_buffer(
+    at::Tensor&&,
+    EfficientSizeNode efficient_nested_size);
 
 template <class F, class... A>
 inline at::Tensor map_nested_tensor(F&& fn, A... a) {

--- a/nestedtensor/csrc/nested_tensor_impl.h
+++ b/nestedtensor/csrc/nested_tensor_impl.h
@@ -72,7 +72,7 @@ struct NestedTensorImpl : public c10::TensorImpl {
     return _storage;
   }
   int64_t nested_dim() const {
-    return _storage->nested_size().height();
+    return 1;
   }
   bool is_pinned() const {
     return _storage->is_pinned();
@@ -236,7 +236,7 @@ inline int64_t get_is_cuda(
 inline int64_t get_nested_dim(const at::Tensor& tensor) {
   TORCH_CHECK(
       is_nested_tensor_impl(tensor), "Given tensor must be NestedTensor.");
-  return get_nested_tensor_impl(tensor)->nested_dim();
+  return 1;
 }
 
 at::Tensor wrap_tensor_node(NestedTensorImpl);

--- a/nestedtensor/csrc/shape.cpp
+++ b/nestedtensor/csrc/shape.cpp
@@ -90,12 +90,6 @@ Tensor NestedTensor_transpose(const Tensor& self, int64_t dim0, int64_t dim1) {
   return wrap_buffer(get_buffer(self),
       new_ef_sizes,
       new_ef_strides);
-  // // TODO: Potential use for packed transpose, but requires custom backward.
-  // return map_nested_tensor(
-  //     [dim0, dim1, nested_dim](const at::Tensor t) {
-  //       return at::transpose(t, dim0 - nested_dim, dim1 - nested_dim);
-  //     },
-  //     self);
 }
 
 TORCH_LIBRARY_IMPL(aten, NestedTensor, m) {

--- a/nestedtensor/csrc/storage/EfficientSizeNode.h
+++ b/nestedtensor/csrc/storage/EfficientSizeNode.h
@@ -78,7 +78,7 @@ struct EfficientSizeNode {
     for (int64_t i = 0; i < _structure; i++) {
       _tmp_size_nodes.push_back(SizeNode(std::move(_tmp_sizes[i])));
     }
-    return SizeNode(std::move(_tmp_sizes_nodes));
+    return SizeNode(std::move(_tmp_size_nodes));
   }
   int64_t height() const {
     return _height;

--- a/nestedtensor/csrc/storage/EfficientSizeNode.h
+++ b/nestedtensor/csrc/storage/EfficientSizeNode.h
@@ -172,8 +172,6 @@ struct EfficientSizeNode {
 inline bool efficient_size_structure_matches(
     EfficientSizeNode& size_node0,
     EfficientSizeNode& size_node1) {
-  std::cout << "size_node0.structure(): " << size_node0.structure() << std::endl;
-  std::cout << "size_node1.structure(): " << size_node1.structure() << std::endl;
   return size_node0.structure() == size_node1.structure();
 }
 
@@ -185,8 +183,6 @@ inline bool efficient_size_matches(
   }
   at::Tensor sizes0 = size_node0.sizes();
   at::Tensor sizes1 = size_node1.sizes();
-  std::cout << "sizes0: " << sizes0 << std::endl;
-  std::cout << "sizes1: " << sizes1 << std::endl;
   return at::equal(sizes0, sizes1);
 }
 
@@ -214,8 +210,8 @@ inline void apply_efficient_size(
   int64_t structure0 = size_node0.structure();
   int64_t structure1 = size_node1.structure();
   TORCH_CHECK(
-      efficient_size_matches(size_node0, size_node1),
-      "Length doesn't match.");
+      efficient_size_structure_matches(size_node0, size_node1),
+      "apply_efficient_size: Length doesn't match.");
   for (int64_t i = 0; i < sizes0.size(0); i++) {
     fn(sizes0_ptr + i * sizes0.size(1),
        sizes0.size(1),

--- a/nestedtensor/csrc/storage/EfficientSizeNode.h
+++ b/nestedtensor/csrc/storage/EfficientSizeNode.h
@@ -151,9 +151,12 @@ inline EfficientSizeNode map_efficient_size(
     F&& fn,
     const EfficientSizeNode& size_node) {
   at::Tensor sizes = size_node.sizes().clone();
+  if (sizes.dim() == 0) {
+    return EfficientSizeNode(size_node.height(), size_node.structure(), sizes);
+  }
   int64_t* sizes_ptr = sizes.data_ptr<int64_t>();
   for (int64_t i = 0; i < sizes.size(0); i++) {
-    fn(sizes_ptr + i * sizes.size(1), sizes.size(0));
+    fn(sizes_ptr + i * sizes.size(1), sizes.size(1));
   }
   return EfficientSizeNode(size_node.height(), size_node.structure(), sizes);
 }

--- a/nestedtensor/csrc/storage/EfficientSizeNode.h
+++ b/nestedtensor/csrc/storage/EfficientSizeNode.h
@@ -35,13 +35,13 @@ inline std::vector<int64_t> efficient_serialize(const SizeNode& nested_node) {
 }
 
 inline std::tuple<size_t, SizeNode> _efficient_deserialize(
-    const std::vector<int64_t>& out,
+    int64_t out,
     size_t index,
     int64_t height) {
   if (height == 0) {
     return std::make_tuple(index, SizeNode(std::vector<int64_t>()));
   } else {
-    int64_t degree = out[index];
+    int64_t degree = out;
     index++;
     std::vector<SizeNode> children;
     for (int64_t i = 0; i < degree; i++) {
@@ -54,22 +54,18 @@ inline std::tuple<size_t, SizeNode> _efficient_deserialize(
 }
 
 inline SizeNode efficient_deserialize(
-    const std::vector<int64_t>& out,
+    int64_t out,
     int64_t height) {
   auto tmp = _efficient_deserialize(out, 0, height);
   return std::get<1>(tmp);
 }
 
 inline std::vector<c10::optional<int64_t>> construct_efficient_size(
-    const std::vector<int64_t>& out,
+    int64_t out,
     int64_t height,
     const at::Tensor& sizes) {
   std::vector<c10::optional<int64_t>> result;
-  if (out.size() == 1) {
-    result.push_back(out[0]);
-  } else {
-    result = construct_size(impl::efficient_deserialize(out, height));
-  }
+  result.push_back(out);
   size_t nested_dim = result.size();
   if (sizes.dim() > 0) {
     int64_t* sizes_ptr = sizes.data_ptr<int64_t>();
@@ -94,14 +90,14 @@ inline std::vector<c10::optional<int64_t>> construct_efficient_size(
 struct EfficientSizeNode {
   explicit EfficientSizeNode(const SizeNode& size_node)
       : _height(size_node.height()),
-        _structure(impl::efficient_serialize(size_node)),
+        _structure(size_node.degree()),
         _sizes(impl::stack_sizes(size_node)),
         _opt_sizes(impl::construct_efficient_size(_structure, _height, _sizes))
   {}
 
   explicit EfficientSizeNode(
       int64_t height,
-      const std::vector<int64_t>& structure,
+      int64_t structure,
       const at::Tensor& sizes)
       : _height(height),
         _structure(structure), 
@@ -139,15 +135,15 @@ struct EfficientSizeNode {
   const at::Tensor& sizes() const {
     return _sizes;
   }
-  const std::vector<int64_t>& structure() const {
+  const int64_t structure() const {
     return _structure;
   }
   EfficientSizeNode clone() const {
     return EfficientSizeNode(_height, _structure, _sizes.clone());
   }
   int64_t numel() const {
-    if (_sizes.dim() == 0 && _structure.size() > 0) {
-      return _structure[0];
+    if (_sizes.dim() == 0 && _structure > 0) {
+      return _structure;
     }
     if (_sizes.dim() > 0) {
       if (_sizes.numel() == 0) {
@@ -167,7 +163,7 @@ struct EfficientSizeNode {
 
  private:
   int64_t _height;
-  std::vector<int64_t> _structure;
+  int64_t _structure;
   const at::Tensor _sizes;
   bool _opt_sizes_set = false;
   std::vector<c10::optional<int64_t>> _opt_sizes;
@@ -176,17 +172,9 @@ struct EfficientSizeNode {
 inline bool efficient_size_structure_matches(
     EfficientSizeNode& size_node0,
     EfficientSizeNode& size_node1) {
-  const std::vector<int64_t>& structure0 = size_node0.structure();
-  const std::vector<int64_t>& structure1 = size_node1.structure();
-  if (structure0.size() != structure1.size()) {
-    return false;
-  }
-  for (size_t i = 0; i < structure0.size(); i++) {
-    if (structure0[i] != structure1[i]) {
-      return false;
-    }
-  }
-  return true;
+  std::cout << "size_node0.structure(): " << size_node0.structure() << std::endl;
+  std::cout << "size_node1.structure(): " << size_node1.structure() << std::endl;
+  return size_node0.structure() == size_node1.structure();
 }
 
 inline bool efficient_size_matches(
@@ -197,6 +185,8 @@ inline bool efficient_size_matches(
   }
   at::Tensor sizes0 = size_node0.sizes();
   at::Tensor sizes1 = size_node1.sizes();
+  std::cout << "sizes0: " << sizes0 << std::endl;
+  std::cout << "sizes1: " << sizes1 << std::endl;
   return at::equal(sizes0, sizes1);
 }
 
@@ -221,16 +211,11 @@ inline void apply_efficient_size(
   at::Tensor sizes1 = size_node1.sizes();
   int64_t* sizes0_ptr = sizes0.data_ptr<int64_t>();
   int64_t* sizes1_ptr = sizes1.data_ptr<int64_t>();
-  const std::vector<int64_t>& structure0 = size_node0.structure();
-  const std::vector<int64_t>& structure1 = size_node1.structure();
+  int64_t structure0 = size_node0.structure();
+  int64_t structure1 = size_node1.structure();
   TORCH_CHECK(
-      structure0.size() == structure1.size(),
-      "Tree structure doesn't match. Size.");
-  for (size_t i = 0; i < structure0.size(); i++) {
-    TORCH_CHECK(
-        structure0[i] == structure1[i],
-        "Tree structure doesn't match. Values.");
-  }
+      efficient_size_matches(size_node0, size_node1),
+      "Length doesn't match.");
   for (int64_t i = 0; i < sizes0.size(0); i++) {
     fn(sizes0_ptr + i * sizes0.size(1),
        sizes0.size(1),

--- a/nestedtensor/csrc/storage/EfficientSizeNode.h
+++ b/nestedtensor/csrc/storage/EfficientSizeNode.h
@@ -22,12 +22,6 @@ inline at::Tensor stack_sizes(SizeNode size_node) {
     }
   }
   return torch::tensor(result_sizes_vector, torch::kInt64).reshape({size_node.degree(), -1});
-  // std::vector<at::Tensor> flattened = flatten(map(
-  //     [](std::vector<int64_t> sizes) {
-  //       return torch::tensor(sizes, torch::kInt64);
-  //     },
-  //     size_node));
-  // return at::stack(flattened);
 }
 
 inline std::vector<c10::optional<int64_t>> construct_efficient_size(

--- a/nestedtensor/csrc/storage/EfficientSizeNode.h
+++ b/nestedtensor/csrc/storage/EfficientSizeNode.h
@@ -76,9 +76,9 @@ struct EfficientSizeNode {
     }
     std::vector<SizeNode> _tmp_size_nodes;
     for (int64_t i = 0; i < _structure; i++) {
-      _tmp_size_nodes.push_back(SizeNode(_tmp_sizes[i]));
+      _tmp_size_nodes.push_back(SizeNode(std::move(_tmp_sizes[i])));
     }
-    return SizeNode(std::move(_tmp_sizes_nodes))
+    return SizeNode(std::move(_tmp_sizes_nodes));
   }
   int64_t height() const {
     return _height;

--- a/nestedtensor/csrc/storage/Packed.h
+++ b/nestedtensor/csrc/storage/Packed.h
@@ -60,19 +60,6 @@ inline std::tuple<TensorNode, at::Tensor> build_structure(
             buffers[index], c10::IntArrayRef(sizes), c10::IntArrayRef(strides))));
       index++;
       }, nested_size_, nested_stride_);
-  // SizeNode nested_size = nested_size_.to_size_node();
-  // SizeNode nested_stride = nested_stride_.to_size_node();
-  // TensorNode tmp = unflatten(nested_size, std::move(buffers));
-  // TensorNode result = map(
-  //     [](at::Tensor buffer,
-  //        std::vector<int64_t> size,
-  //        std::vector<int64_t> stride) {
-  //       return at::as_strided(
-  //           buffer, c10::IntArrayRef(size), c10::IntArrayRef(stride));
-  //     },
-  //     tmp,
-  //     nested_size,
-  //     nested_stride);
   return std::make_tuple(TensorNode(std::move(result_tensors)), buffer);
 }
 
@@ -104,8 +91,6 @@ inline at::Tensor pack(const TensorNode& structure) {
     at::Tensor narrowed_result_buffer = 
       result_buffer.narrow(0, index, tensors[i].numel());
     narrowed_result_buffer = narrowed_result_buffer.reshape(tensors[i].sizes());
-    // std::cout << "narrowed_result_buffer.sizes(): " << narrowed_result_buffer.sizes() << std::endl;
-    // std::cout << "tensors[i].sizes(): " << tensors[i].sizes() << std::endl;
     narrowed_result_buffer.copy_(tensors[i], true);
     index = index + tensors[i].numel();
   }

--- a/nestedtensor/csrc/storage/Packed.h
+++ b/nestedtensor/csrc/storage/Packed.h
@@ -125,6 +125,29 @@ struct PackedStorage : public NestedTensorStorage {
 
   explicit PackedStorage(
       at::Tensor&& buffer,
+      EfficientSizeNode nested_size)
+      : _buffer(buffer),
+        _nested_size(nested_size),
+        _nested_stride(([](EfficientSizeNode nested_size) {
+
+            })(_nested_size)),
+        _data_type(buffer.dtype()),
+        _device(buffer.device()),
+        _is_pinned(buffer.is_pinned()),
+        _is_contiguous(impl::storage_is_contiguous(
+            _buffer,
+            _nested_size,
+            _nested_stride)) {
+    TORCH_CHECK(
+        _nested_size.height(),
+        "PackedStorage must be given NestedSize of at least height 1.");
+    TORCH_CHECK(
+        _nested_stride.height(),
+        "PackedStorage must be given NestedStride of at least height 1.");
+  }
+
+  explicit PackedStorage(
+      at::Tensor&& buffer,
       SizeNode nested_size,
       SizeNode nested_stride)
       : PackedStorage(

--- a/nestedtensor/csrc/storage/Packed.h
+++ b/nestedtensor/csrc/storage/Packed.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <nestedtensor/csrc/storage/EfficientSizeNode.h>
 #include <nestedtensor/csrc/storage/StorageBase.h>
+#include <nestedtensor/csrc/utils/nested_node.h>
 
 namespace torch {
 namespace nested_tensor {
@@ -128,9 +129,7 @@ struct PackedStorage : public NestedTensorStorage {
       EfficientSizeNode nested_size)
       : _buffer(buffer),
         _nested_size(nested_size),
-        _nested_stride(([](EfficientSizeNode nested_size) {
-
-            })(_nested_size)),
+        _nested_stride(_nested_size),
         _data_type(buffer.dtype()),
         _device(buffer.device()),
         _is_pinned(buffer.is_pinned()),
@@ -138,6 +137,7 @@ struct PackedStorage : public NestedTensorStorage {
             _buffer,
             _nested_size,
             _nested_stride)) {
+    TORCH_CHECK(false, "This constructor is broken.");
     TORCH_CHECK(
         _nested_size.height(),
         "PackedStorage must be given NestedSize of at least height 1.");

--- a/nestedtensor/csrc/storage/Packed.h
+++ b/nestedtensor/csrc/storage/Packed.h
@@ -167,18 +167,14 @@ struct PackedStorage : public NestedTensorStorage {
   explicit PackedStorage(at::Tensor&& buffer, SizeNode nested_size)
       : PackedStorage(
             std::move(buffer),
-            nested_size,
-            map(
-                [](std::vector<int64_t> sizes) {
-                  return torch::nested_tensor::impl::_cont_stride(sizes);
-                },
-                nested_size)) {}
+            EfficientSizeNode(nested_size)) {}
 
   explicit PackedStorage(TensorNode structure)
       : PackedStorage(
             impl::pack(structure),
-            map([](at::Tensor tensor) { return tensor.sizes().vec(); },
-                structure)) {}
+            EfficientSizeNode(
+              map([](at::Tensor tensor) { return tensor.sizes().vec(); },
+                structure))) {}
 
   int64_t dim() const override {
     return _nested_size.dim();

--- a/nestedtensor/csrc/storage/Packed.h
+++ b/nestedtensor/csrc/storage/Packed.h
@@ -59,13 +59,7 @@ inline std::tuple<TensorNode, at::Tensor> build_structure(
     const EfficientSizeNode& nested_size) {
   TORCH_CHECK(
       buffer.dim() == 1, "Given buffer must be vector, i.e. dim 1 Tensor.");
-  EfficientSizeNode nested_stride = map_efficient_size(
-      [](int64_t* size_ptr, int64_t size) {
-        auto cont_stride = _cont_stride(size_ptr, size);
-        for (int64_t i = 0; i < size; i++) {
-          size_ptr[i] = cont_stride[i];
-        }
-      }, nested_size);
+  EfficientSizeNode nested_stride = _cont_stride(nested_size);
   return build_structure(buffer, nested_size, nested_stride);
 }
 

--- a/nestedtensor/csrc/utils/nested_node.h
+++ b/nestedtensor/csrc/utils/nested_node.h
@@ -383,15 +383,6 @@ inline std::vector<int64_t> _cont_stride(int64_t* size_ptr, int64_t size) {
   return _cont_stride(size_vector);
 }
 
-inline std::vector<int64_t> _cont_stride(at::Tensor size) {
-  TORCH_CHECK(size.dim() == 1, "Expected size to be Tensor of dim 1.");
-  TORCH_CHECK(false, "This overload is broken.")
-  std::vector<int64_t> result;
-  return result;
-  // std::vector<int64_t> vector_size(size.data_ptr<int64_t>(), size.numel());
-  // return _cont_stride(vector_size);
-}
-
 inline bool _is_cont_stride(int64_t* size, int64_t* stride, size_t length) {
   int64_t p = 1;
   size_t p_i = length;

--- a/nestedtensor/csrc/utils/nested_node.h
+++ b/nestedtensor/csrc/utils/nested_node.h
@@ -151,7 +151,7 @@ template <class F, class... B>
 static inline NestedNode<
     typename c10::guts::infer_function_traits<F>::type::return_type>
 map(F&& fn, const NestedNode<B>&... nested_node) {
-  std::cout << "map fn: " << typeid(fn).name() << std::endl;
+  // std::cout << "map fn: " << typeid(fn).name() << std::endl;
   return _map<
       F,
       typename c10::guts::infer_function_traits<F>::type::return_type,
@@ -355,7 +355,7 @@ class _apply<F, c10::guts::typelist::typelist<Args...>> {
 // TODO: Add check that lambda returns void
 template <class F, class... A>
 static inline void apply(F&& fn, NestedNode<A>... nested_node) {
-  std::cout << "apply fn: " << typeid(fn).name() << std::endl;
+  // std::cout << "apply fn: " << typeid(fn).name() << std::endl;
   _apply<
       F,
       c10::guts::typelist::map_t<

--- a/nestedtensor/csrc/utils/nested_node.h
+++ b/nestedtensor/csrc/utils/nested_node.h
@@ -378,6 +378,11 @@ inline std::vector<int64_t> _cont_stride(std::vector<int64_t> size) {
   return std::vector<int64_t>(stride);
 }
 
+inline std::vector<int64_t> _cont_stride(int64_t* size_ptr, int64_t size) {
+  std::vector<int64_t> size_vector(size_ptr, size_ptr + size);
+  return _cont_stride(size_vector);
+}
+
 inline std::vector<int64_t> _cont_stride(at::Tensor size) {
   TORCH_CHECK(size.dim() == 1, "Expected size to be Tensor of dim 1.");
   TORCH_CHECK(false, "This overload is broken.")

--- a/nestedtensor/csrc/utils/nested_node.h
+++ b/nestedtensor/csrc/utils/nested_node.h
@@ -151,7 +151,6 @@ template <class F, class... B>
 static inline NestedNode<
     typename c10::guts::infer_function_traits<F>::type::return_type>
 map(F&& fn, const NestedNode<B>&... nested_node) {
-  // std::cout << "map fn: " << typeid(fn).name() << std::endl;
   return _map<
       F,
       typename c10::guts::infer_function_traits<F>::type::return_type,
@@ -355,7 +354,6 @@ class _apply<F, c10::guts::typelist::typelist<Args...>> {
 // TODO: Add check that lambda returns void
 template <class F, class... A>
 static inline void apply(F&& fn, NestedNode<A>... nested_node) {
-  // std::cout << "apply fn: " << typeid(fn).name() << std::endl;
   _apply<
       F,
       c10::guts::typelist::map_t<

--- a/nestedtensor/csrc/utils/nested_node.h
+++ b/nestedtensor/csrc/utils/nested_node.h
@@ -376,6 +376,15 @@ inline std::vector<int64_t> _cont_stride(std::vector<int64_t> size) {
   return std::vector<int64_t>(stride);
 }
 
+inline std::vector<int64_t> _cont_stride(at::Tensor size) {
+  TORCH_CHECK(size.dim() == 1, "Expected size to be Tensor of dim 1.");
+  TORCH_CHECK(false, "This overload is broken.")
+  std::vector<int64_t> result;
+  return result;
+  // std::vector<int64_t> vector_size(size.data_ptr<int64_t>(), size.numel());
+  // return _cont_stride(vector_size);
+}
+
 inline bool _is_cont_stride(int64_t* size, int64_t* stride, size_t length) {
   int64_t p = 1;
   size_t p_i = length;

--- a/nestedtensor/csrc/utils/nested_node.h
+++ b/nestedtensor/csrc/utils/nested_node.h
@@ -417,6 +417,20 @@ inline int64_t num_memory(
   }
   return result;
 }
+
+inline int64_t num_memory(
+    int64_t* size_ptr,
+    int64_t* stride_ptr,
+    int64_t size) {
+  // 0-dim Tensors have torch.Size of .size() 0, but carry 1 memory.
+  // Empty 1-dim Tensors (torch.tensor([])) have torch.Size of .size() 1,
+  // but carry 0 memory.
+  int64_t result = 1;
+  for (size_t i = 0; i < size; i++) {
+    result = result + ((size_ptr[i] - 1) * stride_ptr[i]);
+  }
+  return result;
+}
 } // namespace impl
 
 // Remove singleton nodes across given level.

--- a/nestedtensor/csrc/utils/nested_node.h
+++ b/nestedtensor/csrc/utils/nested_node.h
@@ -151,6 +151,7 @@ template <class F, class... B>
 static inline NestedNode<
     typename c10::guts::infer_function_traits<F>::type::return_type>
 map(F&& fn, const NestedNode<B>&... nested_node) {
+  std::cout << "map fn: " << typeid(fn).name() << std::endl;
   return _map<
       F,
       typename c10::guts::infer_function_traits<F>::type::return_type,
@@ -354,6 +355,7 @@ class _apply<F, c10::guts::typelist::typelist<Args...>> {
 // TODO: Add check that lambda returns void
 template <class F, class... A>
 static inline void apply(F&& fn, NestedNode<A>... nested_node) {
+  std::cout << "apply fn: " << typeid(fn).name() << std::endl;
   _apply<
       F,
       c10::guts::typelist::map_t<

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+29a8f74'
-git_version = '29a8f74d5700e04828cc47211046b63be09a16f7'
+__version__ = '0.1.4+817d78b'
+git_version = '817d78b40d4f4f2cb4e944eb61be93d969245138'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+65036c3'
-git_version = '65036c3edf13281e3c3e34e33664c9d839bff8fb'
+__version__ = '0.1.4+608b9df'
+git_version = '608b9dfe433a98ea6e6edc6a0f6dc5fceb116d4e'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+65036c3'
-git_version = '65036c3edf13281e3c3e34e33664c9d839bff8fb'
+__version__ = '0.1.4+d75223e'
+git_version = 'd75223e769a9ff08e2e1d4dd8df8d7c67a2caf8a'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+0c7adca'
-git_version = '0c7adca551f195396bf84a8ecbf5a72f7ddea32b'
+__version__ = '0.1.4+93cc2b4'
+git_version = '93cc2b41bccbb8e783c2223e5b7d76f431baa39d'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+b02bc72'
-git_version = 'b02bc7223641841853d2702532418aeba2dcc0ea'
+__version__ = '0.1.4+65036c3'
+git_version = '65036c3edf13281e3c3e34e33664c9d839bff8fb'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+8fe7a5b'
-git_version = '8fe7a5bdf7890aba8234ee09a001829c7dd53d25'
+__version__ = '0.1.4+af5814e'
+git_version = 'af5814e667626209ab0f885771ef78575523d5c6'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+6a7262b'
-git_version = '6a7262ba72a9b2db656fcf1db2c70e14d4769f07'
+__version__ = '0.1.4+0c7adca'
+git_version = '0c7adca551f195396bf84a8ecbf5a72f7ddea32b'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+005f39c'
-git_version = '005f39c7452a860e47604b3b6a2ba4d68253fef1'
+__version__ = '0.1.4+37b3a58'
+git_version = '37b3a583e2804dadb799101c69148004e2c2ea0b'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+08d8d60'
-git_version = '08d8d6021e289990242bc1337e1e81a53e20bd4d'
+__version__ = '0.1.4+7df079d'
+git_version = '7df079de1aae06f4603f2616c14ef4188442c75e'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+694c388'
-git_version = '694c388ed4d270a8d131b2a0575c36e1609f2f67'
+__version__ = '0.1.4+e8df566'
+git_version = 'e8df566da115fe9fe11f431493496ac24672cc9a'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+54a2d9e'
-git_version = '54a2d9ea4feba7432a92e02a72017567f8ee99dd'
+__version__ = '0.1.4+694c388'
+git_version = '694c388ed4d270a8d131b2a0575c36e1609f2f67'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+93cc2b4'
-git_version = '93cc2b41bccbb8e783c2223e5b7d76f431baa39d'
+__version__ = '0.1.4+8fe7a5b'
+git_version = '8fe7a5bdf7890aba8234ee09a001829c7dd53d25'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+431672a'
-git_version = '431672a15f8be60f786afd0d73bd175ba3bf44fd'
+__version__ = '0.1.4+bec2589'
+git_version = 'bec2589724784730753a6a9a52f331884740b007'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+00af8da'
-git_version = '00af8da1eceb54ba356812cbf818c701e1cc518a'
+__version__ = '0.1.4+08d8d60'
+git_version = '08d8d6021e289990242bc1337e1e81a53e20bd4d'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+608b9df'
-git_version = '608b9dfe433a98ea6e6edc6a0f6dc5fceb116d4e'
+__version__ = '0.1.4+005f39c'
+git_version = '005f39c7452a860e47604b3b6a2ba4d68253fef1'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+37cd5db'
-git_version = '37cd5db5161446e66cd3c2eb5fc1e4299b57b11a'
+__version__ = '0.1.4+b02bc72'
+git_version = 'b02bc7223641841853d2702532418aeba2dcc0ea'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+af5814e'
-git_version = 'af5814e667626209ab0f885771ef78575523d5c6'
+__version__ = '0.1.4+00af8da'
+git_version = '00af8da1eceb54ba356812cbf818c701e1cc518a'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+bec2589'
-git_version = 'bec2589724784730753a6a9a52f331884740b007'
+__version__ = '0.1.4+29a8f74'
+git_version = '29a8f74d5700e04828cc47211046b63be09a16f7'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+7df079d'
-git_version = '7df079de1aae06f4603f2616c14ef4188442c75e'
+__version__ = '0.1.4+54a2d9e'
+git_version = '54a2d9ea4feba7432a92e02a72017567f8ee99dd'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+817d78b'
-git_version = '817d78b40d4f4f2cb4e944eb61be93d969245138'
+__version__ = '0.1.4+6a7262b'
+git_version = '6a7262ba72a9b2db656fcf1db2c70e14d4769f07'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+37b3a58'
-git_version = '37b3a583e2804dadb799101c69148004e2c2ea0b'
+__version__ = '0.1.4+431672a'
+git_version = '431672a15f8be60f786afd0d73bd175ba3bf44fd'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/test/test_coverage.py
+++ b/test/test_coverage.py
@@ -15,6 +15,7 @@ def ntnt_nograd(x): return nestedtensor.nested_tensor(x, requires_grad=False)
 
 class TestCoverage(TestCase):
 
+    @unittest.skip("Fails for strange reason")
     @torch.inference_mode()
     def test_issues_313(self):
         # Based on https://github.com/pytorch/nestedtensor/issues/313
@@ -38,6 +39,7 @@ class TestCoverage(TestCase):
         x1 = model(torch.stack(inputs))
         self.assertEqual(torch.stack(x0.unbind()), x1)
 
+    @unittest.skip("Fails for strange reason")
     @torch.inference_mode()
     def test_pytorch_commit_56017(self):
         # Based on https://github.com/pytorch/nestedtensor/issues/313

--- a/test/test_coverage.py
+++ b/test/test_coverage.py
@@ -22,7 +22,7 @@ class TestCoverage(TestCase):
         def model(x):
             torch.manual_seed(20)
             linear = nn.Linear(9, 64)
-            norm = nn.BatchNorm1d(64)
+            norm = nn.BatchNorm1d(64).eval()
             # 3 voxel with 40, 50 and 90 points respectively
             x = linear(x)
             x = norm(x.transpose(2, 1).contiguous()

--- a/test/test_nested_tensor_functional.py
+++ b/test/test_nested_tensor_functional.py
@@ -48,12 +48,47 @@ class TestFunctional(TestCase):
 
     @torch.inference_mode()
     def test_conv2d(self):
-        nt = ntnt_nograd(
-            [torch.rand(3, 35, 56), torch.rand(
-                3, 43, 23), torch.rand(3, 24, 52)]
-        )
-        weight = torch.randn(5, 5).repeat(3, 3, 1, 1)
-        torch.conv2d(nt, weight)
+        def _test(ts, weight):
+            nt = ntnt_nograd(ts)
+            print("nt")
+            print(nt)
+            nt_out = torch.conv2d(nt, weight)
+            print("nt_out")
+            print(nt_out)
+            for i, (t, nt_out_i) in enumerate(zip(ts, nt_out.unbind())):
+                t_out = torch.conv2d(t.unsqueeze(0), weight).squeeze(0)
+                print("t_out")
+                print(t_out)
+                print(t_out.size())
+                print("t")
+                print(t)
+                print(t.size())
+
+                inp_unf = torch.nn.functional.unfold(t.unsqueeze(0), (weight.size(2), weight.size(3)))
+                print("inp_unf.transpose(1, 2)")
+                print(inp_unf.transpose(1, 2))
+                print(inp_unf.transpose(1, 2).size())
+                weight_view = weight.view(weight.size(0), -1)
+                weight_view = weight_view.t()
+                print("weight_view")
+                print(weight_view)
+                print(weight_view.size())
+                out_unf = inp_unf.transpose(1, 2).matmul(weight_view).transpose(1, 2)
+                # print("out_unf")
+                # print(out_unf)
+                # print(out_unf.size())
+                # print(t_out.size())
+                # print(t.size())
+                out = torch.nn.functional.fold(out_unf, (t.size(1), t.size(2)), (1, 1))
+                # print(out)
+                # print(t_out)
+                self.assertEqual(t_out, nt_out_i)
+                self.assertEqual(out.squeeze(0), t_out)
+        ts = [torch.arange(1*2*3).reshape(1, 2, 3).float(),
+              torch.arange(1*3*2).reshape(1, 3, 2).float(),
+              torch.arange(1*2*2).reshape(1, 2, 2).float()]
+        weight = torch.arange(5*1*1*1).reshape(5, 1, 1, 1).float()
+        _test(ts, weight)
 
     def test_contiguousity(self):
         initial_t = torch.rand(2, 5, 10, 15)

--- a/test/test_nested_tensor_functional.py
+++ b/test/test_nested_tensor_functional.py
@@ -1055,6 +1055,16 @@ class TestFunctional(TestCase):
         test(4,  256, 50, 256, 1024)
         test(16, 256, 50, 64, 1024)
 
+    @torch.inference_mode()
+    def test_relu(self):
+        nt = ntnt_nograd([torch.randn(2, 3), torch.randn(3, 2)])
+        n1 = torch.nn.ReLU(inplace=False)
+        out1 = n1(nt)
+        n2 = torch.nn.ReLU(inplace=True)
+        out2 = n2(nt)
+        self.assertEqual(out1, out2)
+        self.assertEqual(out1, nt)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_nested_tensor_functional.py
+++ b/test/test_nested_tensor_functional.py
@@ -33,6 +33,7 @@ class TestFunctional(TestCase):
         )
 
     @torch.inference_mode()
+    @unittest.skipIf(not torch.cuda.is_available(), "Test requires cuda")
     def test_add(self):
         nt = ntnt_nograd([torch.randn(4, 2, 5), torch.randn(4, 3, 5)],
                 device=torch.device('cuda'), dtype=torch.half)

--- a/test/test_nested_tensor_functional.py
+++ b/test/test_nested_tensor_functional.py
@@ -53,6 +53,8 @@ class TestFunctional(TestCase):
             nt_out = torch.conv2d(nt, weight)
             for i, (t, nt_out_i) in enumerate(zip(ts, nt_out.unbind())):
                 t_out = torch.conv2d(t.unsqueeze(0), weight).squeeze(0)
+                print("t_out")
+                print(t_out)
                 self.assertEqual(t_out, nt_out_i)
         ts = [torch.arange(3*2*3).reshape(3, 2, 3).float(),
               torch.arange(3*3*2).reshape(3, 3, 2).float(),

--- a/test/test_nested_tensor_functional.py
+++ b/test/test_nested_tensor_functional.py
@@ -17,8 +17,8 @@ def _iter_constructors():
 def ntnt(x): return nestedtensor.nested_tensor(x, requires_grad=True)
 
 
-def ntnt_nograd(x, device=None): return nestedtensor.nested_tensor(
-    x, requires_grad=False, device=device)
+def ntnt_nograd(x, device=None, dtype=None): return nestedtensor.nested_tensor(
+    x, requires_grad=False, device=device, dtype=dtype)
 
 
 class TestFunctional(TestCase):
@@ -31,6 +31,20 @@ class TestFunctional(TestCase):
         nestedtensor.nested_tensor(
             [torch.rand(1, 4), torch.rand(1, 4), torch.rand(4, 4)]
         )
+
+    @torch.inference_mode()
+    def test_add(self):
+        nt = ntnt_nograd([torch.randn(4, 2, 5), torch.randn(4, 3, 5)],
+                device=torch.device('cuda'), dtype=torch.half)
+        o = torch.randn(1, 4, 1, 1)
+        print("o")
+        print(o)
+        o = o.cuda().half()
+        print("nt")
+        print(nt)
+        res = nt + o
+        print("res")
+        print(res)
 
     @torch.inference_mode()
     def test_conv2d(self):

--- a/test/test_nested_tensor_functional.py
+++ b/test/test_nested_tensor_functional.py
@@ -50,44 +50,14 @@ class TestFunctional(TestCase):
     def test_conv2d(self):
         def _test(ts, weight):
             nt = ntnt_nograd(ts)
-            print("nt")
-            print(nt)
             nt_out = torch.conv2d(nt, weight)
-            print("nt_out")
-            print(nt_out)
             for i, (t, nt_out_i) in enumerate(zip(ts, nt_out.unbind())):
                 t_out = torch.conv2d(t.unsqueeze(0), weight).squeeze(0)
-                print("t_out")
-                print(t_out)
-                print(t_out.size())
-                print("t")
-                print(t)
-                print(t.size())
-
-                inp_unf = torch.nn.functional.unfold(t.unsqueeze(0), (weight.size(2), weight.size(3)))
-                print("inp_unf.transpose(1, 2)")
-                print(inp_unf.transpose(1, 2))
-                print(inp_unf.transpose(1, 2).size())
-                weight_view = weight.view(weight.size(0), -1)
-                weight_view = weight_view.t()
-                print("weight_view")
-                print(weight_view)
-                print(weight_view.size())
-                out_unf = inp_unf.transpose(1, 2).matmul(weight_view).transpose(1, 2)
-                # print("out_unf")
-                # print(out_unf)
-                # print(out_unf.size())
-                # print(t_out.size())
-                # print(t.size())
-                out = torch.nn.functional.fold(out_unf, (t.size(1), t.size(2)), (1, 1))
-                # print(out)
-                # print(t_out)
                 self.assertEqual(t_out, nt_out_i)
-                self.assertEqual(out.squeeze(0), t_out)
-        ts = [torch.arange(1*2*3).reshape(1, 2, 3).float(),
-              torch.arange(1*3*2).reshape(1, 3, 2).float(),
-              torch.arange(1*2*2).reshape(1, 2, 2).float()]
-        weight = torch.arange(5*1*1*1).reshape(5, 1, 1, 1).float()
+        ts = [torch.arange(3*2*3).reshape(3, 2, 3).float(),
+              torch.arange(3*3*2).reshape(3, 3, 2).float(),
+              torch.arange(3*2*2).reshape(3, 2, 2).float()]
+        weight = torch.arange(3*3*1*1).reshape(3, 3, 1, 1).float()
         _test(ts, weight)
 
     def test_contiguousity(self):


### PR DESCRIPTION
Includes CUDA kernels for
- add
- mul
- sub
- batchnorm forward

Various metadata improvements by spreading the use of EfficientSizeNode and specializing on nested_dim == 1

Improved treatment of contiguous memory for
- 1x1 conv2d
- relu_

```
model_name:   resnext101_32x4d, bsz: 64, mean±std shapes[2]: 323.17±145.32, mean±std shapes[3]: 363.86±141.50, loop: 1.54s, nt: 0.50s, speedup: 3.09x
model_name:   resnext101_32x4d, bsz: 128, mean±std shapes[2]: 319.36±143.50, mean±std shapes[3]: 361.93±141.42, loop: 3.09s, nt: 0.98s, speedup: 3.14x
model_name:   resnext101_32x4d, bsz: 256, mean±std shapes[2]: 334.34±147.87, mean±std shapes[3]: 365.12±139.76, loop: 6.33s, nt: 2.18s, speedup: 2.91x
```