### PR TITLE
Faster padding - fuse fill, reduce overhead

### DIFF
--- a/benchmarks/classy.py
+++ b/benchmarks/classy.py
@@ -21,7 +21,7 @@ def benchmark_torch_function(iters, f, *args, **kwargs):
     if torch.cuda.is_available():
         end_event.record()
         torch.cuda.synchronize()
-        return start_event.elapsed_time(end_event) / 1e3
+        return start_event.elapsed_time(end_event)
     else:
         return (time.time() - t0)
 
@@ -65,10 +65,10 @@ def run_benchmark(iters, shapes, model, model_name, bsz):
     print(f" mean±std shapes[2]: {shapes_2_array.mean():.2f}±{shapes_2_array.std():.2f},", end='')
     print(f" mean±std shapes[3]: {shapes_3_array.mean():.2f}±{shapes_3_array.std():.2f},", end='')
     print(f" padded_size: {tuple(ts_padded.size())},", end='')
-    print(f" loop: {loop_time / iters:.2f}s, nt: {nt_time / iters:.2f}s, padded: {padded_time / iters:.2f}s, speedup: {loop_time / nt_time:.2f}x")
+    print(f" loop: {loop_time / iters:.2f}ms, nt: {nt_time / iters:.2f}ms, padded: {padded_time / iters:.2f}ms, speedup: {loop_time / nt_time:.2f}x")
 
 if __name__ == "__main__":
-    iters = 1
+    iters = 10
 
     def _benchmark(model_name, bsz):
         model = build_model({"name": model_name})

--- a/benchmarks/classy.py
+++ b/benchmarks/classy.py
@@ -65,7 +65,7 @@ def run_benchmark(iters, shapes, model, model_name, bsz):
     print(f" mean±std shapes[2]: {shapes_2_array.mean():.2f}±{shapes_2_array.std():.2f},", end='')
     print(f" mean±std shapes[3]: {shapes_3_array.mean():.2f}±{shapes_3_array.std():.2f},", end='')
     print(f" padded_size: {tuple(ts_padded.size())},", end='')
-    print(f" loop: {loop_time / iters:.2f}ms, nt: {nt_time / iters:.2f}ms, padded: {padded_time / iters:.2f}ms, speedup: {loop_time / nt_time:.2f}x")
+    print(f" loop: {loop_time / iters:7.2f}ms, nt: {nt_time / iters:7.2f}ms, padded: {padded_time / iters:7.2f}ms, speedup: {loop_time / nt_time:.2f}x")
 
 if __name__ == "__main__":
     iters = 10

--- a/nestedtensor/csrc/cuda/padding.h
+++ b/nestedtensor/csrc/cuda/padding.h
@@ -12,6 +12,7 @@ template <typename T>
 void add_padding_kernelLauncher(
     T* input,
     T* output,
+    T padding_value,
     const int* offsets,
     const int* input_sizes,
     int input_dim,

--- a/nestedtensor/csrc/masking.cpp
+++ b/nestedtensor/csrc/masking.cpp
@@ -505,12 +505,13 @@ Tensor to_padded_tensor(Tensor nt, double padding) {
       Tensor offsets = batch_offsets_from_efficient_size(esize);
       std::vector<int64_t> new_size = padded_size_from_efficient_size(esize);
       at::cuda::CUDAStream defaultStream = at::cuda::getDefaultCUDAStream();
-      Tensor output;
-      if (padding == 0) {
-        output = at::zeros(IntArrayRef(new_size), nt_buffer.options());
-      } else {
-        output = nt_buffer.new_full(IntArrayRef(new_size), padding, nt_buffer.options());
-      }
+      // Tensor output;
+      Tensor output = at::empty(IntArrayRef(new_size), nt_buffer.options());
+      // if (padding == 0) {
+      //   output = at::zeros(IntArrayRef(new_size), nt_buffer.options());
+      // } else {
+      //   output = nt_buffer.new_full(IntArrayRef(new_size), padding, nt_buffer.options());
+      // }
       Tensor new_size_tensor = torch::tensor(new_size);
 
       int64_t input_dim = nt_sizes.size(1);
@@ -533,6 +534,7 @@ Tensor to_padded_tensor(Tensor nt, double padding) {
         nested_tensor::cuda::add_padding_kernelLauncher(
             nt_buffer.data_ptr<c10::Half>(),
             output.data_ptr<c10::Half>(),
+            (c10::Half)(padding),
             offsets.data_ptr<int>(),
             nt_sizes.data_ptr<int>(),
             input_dim,
@@ -545,6 +547,7 @@ Tensor to_padded_tensor(Tensor nt, double padding) {
         nested_tensor::cuda::add_padding_kernelLauncher(
             nt_buffer.data_ptr<float>(),
             output.data_ptr<float>(),
+            (float)(padding),
             offsets.data_ptr<int>(),
             nt_sizes.data_ptr<int>(),
             input_dim,

--- a/nestedtensor/csrc/masking.cpp
+++ b/nestedtensor/csrc/masking.cpp
@@ -500,9 +500,9 @@ Tensor to_padded_tensor(Tensor nt, double padding) {
       } else {
         output = nt_buffer.new_full(IntArrayRef(new_size), padding, nt_buffer.options());
       }
-      // Tensor new_size_tensor = torch::tensor(new_size);
+      Tensor new_size_tensor = torch::tensor(new_size);
 
-      // new_size_tensor = new_size_tensor.to(at::Device(kCUDA), torch::kInt32, true, true);
+      new_size_tensor = new_size_tensor.to(at::Device(kCUDA), torch::kInt32, true, true);
       offsets = offsets.to(at::Device(kCUDA), torch::kInt32, true, true);
       nt_sizes = nt_sizes.to(at::Device(kCUDA), torch::kInt32, true, true);
 
@@ -513,7 +513,7 @@ Tensor to_padded_tensor(Tensor nt, double padding) {
             offsets.data_ptr<int>(),
             nt_sizes.data_ptr<int>(),
             nt_sizes.size(1),
-            new_size, // _tensor.data_ptr<int>(),
+            new_size_tensor.data_ptr<int>(),
             nt_sizes.size(0),
             defaultStream);
         return output;
@@ -525,7 +525,7 @@ Tensor to_padded_tensor(Tensor nt, double padding) {
             offsets.data_ptr<int>(),
             nt_sizes.data_ptr<int>(),
             nt_sizes.size(1),
-            new_size, //_tensor.data_ptr<int>(),
+            new_size_tensor.data_ptr<int>(),
             nt_sizes.size(0),
             defaultStream);
         return output;

--- a/nestedtensor/csrc/masking.cpp
+++ b/nestedtensor/csrc/masking.cpp
@@ -505,13 +505,7 @@ Tensor to_padded_tensor(Tensor nt, double padding) {
       Tensor offsets = batch_offsets_from_efficient_size(esize);
       std::vector<int64_t> new_size = padded_size_from_efficient_size(esize);
       at::cuda::CUDAStream defaultStream = at::cuda::getDefaultCUDAStream();
-      // Tensor output;
       Tensor output = at::empty(IntArrayRef(new_size), nt_buffer.options());
-      // if (padding == 0) {
-      //   output = at::zeros(IntArrayRef(new_size), nt_buffer.options());
-      // } else {
-      //   output = nt_buffer.new_full(IntArrayRef(new_size), padding, nt_buffer.options());
-      // }
       Tensor new_size_tensor = torch::tensor(new_size);
 
       int64_t input_dim = nt_sizes.size(1);

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+7958211'
-git_version = '7958211d505470ac5e21d9c81e6db7fc5862a29e'
+__version__ = '0.1.4+036a159'
+git_version = '036a15938527fbf84805e96c9679cf7e4d432b0c'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+036a159'
-git_version = '036a15938527fbf84805e96c9679cf7e4d432b0c'
+__version__ = '0.1.4+54117b5'
+git_version = '54117b58363575602eab13131808959482a13511'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+54117b5'
-git_version = '54117b58363575602eab13131808959482a13511'
+__version__ = '0.1.4+40b4a63'
+git_version = '40b4a637ed257b0cc6dc09bd87b0508735ef4015'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/test/test_nested_tensor_class.py
+++ b/test/test_nested_tensor_class.py
@@ -757,39 +757,42 @@ class TestNestedTensor(TestCase):
                                lambda: nt.to_sparse_csr_tensor())
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not enabled.")
-    def test_to_paded_tensor_cuda_dim2(self):
+    def test_to_padded_tensor_cuda_dim2(self):
         import random
         random.seed(1010)
         tensors = [torch.randn(random.randint(3, 30)) for _ in range(5)]
         nt = ntnt_nograd(tensors, device=torch.device('cuda'))
-        data0 = nt.to_padded_tensor(padding=0)
+        data0 = nt.to_padded_tensor(padding=1)
         nt = ntnt_nograd(tensors, device=torch.device('cpu'))
-        data1, _ = nt.to_tensor_mask()
+        data1, mask1 = nt.to_tensor_mask()
+        data1.masked_fill_(mask1.logical_not(), 1)
         self.assertEqual(data0, data1)
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not enabled.")
-    def test_to_paded_tensor_cuda_dim3(self):
+    def test_to_padded_tensor_cuda_dim3(self):
         import random
         random.seed(1010)
         tensors = [torch.randn(random.randint(3, 30), random.randint(3, 30))
                    for _ in range(5)]
         nt = ntnt_nograd(tensors, device=torch.device('cuda'))
-        data0 = nt.to_padded_tensor(padding=0)
+        data0 = nt.to_padded_tensor(padding=1)
         nt = ntnt_nograd(tensors, device=torch.device('cpu'))
-        data1, _ = nt.to_tensor_mask()
+        data1, mask1 = nt.to_tensor_mask()
+        data1.masked_fill_(mask1.logical_not(), 1)
         self.assertEqual(data0, data1)
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not enabled.")
-    def test_to_paded_tensor_cuda_dim4(self):
+    def test_to_padded_tensor_cuda_dim4(self):
         import random
         random.seed(1010)
         tensors = [torch.randn(random.randint(3, 30),
                                random.randint(3, 30),
                                random.randint(3, 30)) for _ in range(5)]
         nt = ntnt_nograd(tensors, device=torch.device('cuda'))
-        data0 = nt.to_padded_tensor(padding=0)
+        data0 = nt.to_padded_tensor(padding=1)
         nt = ntnt_nograd(tensors, device=torch.device('cpu'))
-        data1, _ = nt.to_tensor_mask()
+        data1, mask1 = nt.to_tensor_mask()
+        data1.masked_fill_(mask1.logical_not(), 1)
         self.assertEqual(data0, data1)
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not enabled.")


### PR DESCRIPTION
Master
```
model_name:   resnext101_32x4d, bsz:  16, mean±std shapes[2]: 256.75±135.80, mean±std shapes[3]: 370.56±148.10, padded_size: (16, 3, 561, 563), loop:  364.19ms, nt:   98.25ms, padded:  113.14ms, speedup: 3.71x
model_name:   resnext101_32x4d, bsz:  32, mean±std shapes[2]: 304.19±155.05, mean±std shapes[3]: 330.72±145.72, padded_size: (32, 3, 566, 564), loop:  740.61ms, nt:  157.64ms, padded:  199.59ms, speedup: 4.70x
model_name:   resnext101_32x4d, bsz:  64, mean±std shapes[2]: 323.17±145.32, mean±std shapes[3]: 363.86±141.50, padded_size: (64, 3, 567, 591), loop: 1481.89ms, nt:  324.53ms, padded:  410.88ms, speedup: 4.57x
model_name:   resnext101_32x4d, bsz: 128, mean±std shapes[2]: 319.36±143.50, mean±std shapes[3]: 361.93±141.42, padded_size: (128, 3, 593, 599), loop: 2969.81ms, nt:  663.22ms, padded:  899.91ms, speedup: 4.48x
```

Branch
```
model_name:   resnext101_32x4d, bsz:  16, mean±std shapes[2]: 256.75±135.80, mean±std shapes[3]: 370.56±148.10, padded_size: (16, 3, 561, 563), loop:  370.88ms, nt:   94.31ms, padded:  113.61ms, speedup: 3.93x
model_name:   resnext101_32x4d, bsz:  32, mean±std shapes[2]: 304.19±155.05, mean±std shapes[3]: 330.72±145.72, padded_size: (32, 3, 566, 564), loop:  756.39ms, nt:  152.60ms, padded:  199.53ms, speedup: 4.96x
model_name:   resnext101_32x4d, bsz:  64, mean±std shapes[2]: 323.17±145.32, mean±std shapes[3]: 363.86±141.50, padded_size: (64, 3, 567, 591), loop: 1518.46ms, nt:  310.15ms, padded:  410.08ms, speedup: 4.90x
model_name:   resnext101_32x4d, bsz: 128, mean±std shapes[2]: 319.36±143.50, mean±std shapes[3]: 361.93±141.42, padded_size: (128, 3, 593, 599), loop: 3042.62ms, nt:  629.73ms, padded:  899.47ms, speedup: 4.83x
```