### PR TITLE
Faster batchnorm inference

### DIFF
--- a/benchmarks/classy.py
+++ b/benchmarks/classy.py
@@ -46,9 +46,9 @@ def run_benchmark(iters, shapes, model, model_name, bsz):
 
     # Test
     outputs_nt = model(ts_nt)
-    # import time; time.sleep(1)
-    # outputs_nt = model(ts_nt)
-    # import sys; sys.exit(1)
+    import time; time.sleep(1)
+    outputs_nt = model(ts_nt)
+    import sys; sys.exit(1)
     model_outputs = _loop()
     for mo, ntmo in zip(model_outputs, outputs_nt.unbind()):
         # Using float16 tolerances from torch/testing/_core.yp

--- a/benchmarks/classy.py
+++ b/benchmarks/classy.py
@@ -46,9 +46,9 @@ def run_benchmark(iters, shapes, model, model_name, bsz):
 
     # Test
     outputs_nt = model(ts_nt)
-    import time; time.sleep(1)
-    outputs_nt = model(ts_nt)
-    import sys; sys.exit(1)
+    # import time; time.sleep(1)
+    # outputs_nt = model(ts_nt)
+    # import sys; sys.exit(1)
     model_outputs = _loop()
     for mo, ntmo in zip(model_outputs, outputs_nt.unbind()):
         # Using float16 tolerances from torch/testing/_core.yp

--- a/nestedtensor/csrc/autograd_functions.cpp
+++ b/nestedtensor/csrc/autograd_functions.cpp
@@ -134,7 +134,7 @@ Tensor NestedTensor_batch_norm(
     Tensor output = input;
     output = NestedTensor_contiguous(output);
     Tensor input_buffer = get_buffer(output);
-    Tensor output_buffer = input_buffer.clone();
+    // Tensor output_buffer = input_buffer.clone();
   
     auto self_opt_sizes = get_opt_sizes(input);
   
@@ -170,13 +170,15 @@ Tensor NestedTensor_batch_norm(
         c10::Half((float)(eps)),
         weight_ptr,
         bias_ptr,
-        output_buffer.data_ptr<c10::Half>(),
+        input_buffer.data_ptr<c10::Half>(),
+        // output_buffer.data_ptr<c10::Half>(),
         (int)(*self_opt_sizes[0] * *self_opt_sizes[1]),
         (int)(*self_opt_sizes[0]),
         nt_sizes.data_ptr<int>(),
         defaultStream
         );
-    return wrap_buffer(std::move(output_buffer), get_efficient_nested_size(output), get_efficient_nested_stride(output));
+    // return wrap_buffer(std::move(output_buffer), get_efficient_nested_size(output), get_efficient_nested_stride(output));
+    return wrap_buffer(std::move(input_buffer), get_efficient_nested_size(output), get_efficient_nested_stride(output));
   }
 #endif
 

--- a/nestedtensor/csrc/cuda/add.cu
+++ b/nestedtensor/csrc/cuda/add.cu
@@ -145,11 +145,11 @@ void sub_scalar_kernelLauncher(
 __global__
 void batchnorm_inference(
     const c10::Half* input,
-    c10::Half* mean,
-    c10::Half* running_var,
-    c10::Half eps,
-    c10::Half* weight,
-    c10::Half* bias,
+    const c10::Half* mean,
+    const c10::Half* running_var,
+    const c10::Half eps,
+    const c10::Half* weight,
+    const c10::Half* bias,
     c10::Half* output,
     const int input_outer_stride,
     const int* offsets)
@@ -168,7 +168,6 @@ void batchnorm_inference(
 
   int input_offset = offsets[batch_id] + tid;
   int id = 0;
-  // printf("num_chunks: %d\n", num_chunks);
   for (; id < num_chunks; id++) {
     output[input_offset] = __ldg(reinterpret_cast<const __half*>(input) + input_offset) * value - value2;
     input_offset += grain_size;

--- a/nestedtensor/csrc/cuda/add.cu
+++ b/nestedtensor/csrc/cuda/add.cu
@@ -144,7 +144,7 @@ void sub_scalar_kernelLauncher(
 
 __global__
 void batchnorm_inference(
-    c10::Half* input,
+    const c10::Half* input,
     c10::Half* mean,
     c10::Half* running_var,
     c10::Half eps,
@@ -155,26 +155,26 @@ void batchnorm_inference(
     const int* offsets)
 {
   const int batch_id  = blockIdx.x;
+  const int grid_id  = blockIdx.y;
   const int scalars_id  = batch_id / input_outer_stride;
-  const int grain_size = blockDim.x;
-  const int tid = threadIdx.x;
+  const int grain_size = 256 * 2;
+  const int tid = threadIdx.x + grid_id * 256;
   const int range = (offsets[batch_id + 1] - offsets[batch_id]);
   const int num_chunks = range / grain_size;
   c10::Half value = running_var[scalars_id] + eps;
   value = hrsqrt(value);
   value = value * weight[scalars_id];
-  for (int id = 0; id < num_chunks; id++) {
-    output[offsets[batch_id] + id * grain_size + tid] =
-      (((input[offsets[batch_id] + id * grain_size + tid] - mean[scalars_id])
-       * value)
-       + bias[scalars_id]);
+  c10::Half value2 = mean[scalars_id] * value - bias[scalars_id];
+
+  int input_offset = offsets[batch_id] + tid;
+  int id = 0;
+  // printf("num_chunks: %d\n", num_chunks);
+  for (; id < num_chunks; id++) {
+    output[input_offset] = __ldg(reinterpret_cast<const __half*>(input) + input_offset) * value - value2;
+    input_offset += grain_size;
   }
-  const int leftover = num_chunks * grain_size;
-  if (leftover + tid < range) {
-    output[offsets[batch_id] + leftover + tid] =
-      (((input[offsets[batch_id] + leftover + tid] - mean[scalars_id])
-       * value)
-       + bias[scalars_id]);
+  if (input_offset < offsets[batch_id + 1]) { //leftover + tid < range) {
+    output[input_offset] = __ldg(reinterpret_cast<const __half*>(input) + input_offset) * value - value2;
   }
 }
 
@@ -193,6 +193,7 @@ void batchnorm_inference_kernelLauncher(
 {
   dim3 grid;
   grid.x = batch_size;
+  grid.y = 2;
 
   batchnorm_inference<<<grid, 256, 0, stream>>>(
       input,

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+40b4a63'
-git_version = '40b4a637ed257b0cc6dc09bd87b0508735ef4015'
+__version__ = '0.1.4+e56fbdb'
+git_version = 'e56fbdb0ae2974fdf8b3d4f1c5648ffc86de487e'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION

--- a/nestedtensor/version.py
+++ b/nestedtensor/version.py
@@ -1,5 +1,5 @@
-__version__ = '0.1.4+e56fbdb'
-git_version = 'e56fbdb0ae2974fdf8b3d4f1c5648ffc86de487e'
+__version__ = '0.1.4+d80c2ce'
+git_version = 'd80c2ce99ebe26c88d1195bc79baebaa6afcc223'
 from nestedtensor import _C
 if hasattr(_C, 'CUDA_VERSION'):
     cuda = _C.CUDA_VERSION


### PR DESCRIPTION
In-place calculation and more blocks.

Master

```
model_name:   resnext101_32x4d, bsz:  16, mean±std shapes[2]: 256.75±135.80, mean±std shapes[3]: 370.56±148.10, padded_size: (16, 3, 561, 563), loop:  368.53ms, nt:   94.62ms, padded:  113.88ms, speedup: 3.89x
model_name:   resnext101_32x4d, bsz:  32, mean±std shapes[2]: 304.19±155.05, mean±std shapes[3]: 330.72±145.72, padded_size: (32, 3, 566, 564), loop:  751.15ms, nt:  152.72ms, padded:  199.85ms, speedup: 4.92x
model_name:   resnext101_32x4d, bsz:  64, mean±std shapes[2]: 323.17±145.32, mean±std shapes[3]: 363.86±141.50, padded_size: (64, 3, 567, 591), loop: 1502.62ms, nt:  309.38ms, padded:  409.75ms, speedup: 4.86x
model_name:   resnext101_32x4d, bsz: 128, mean±std shapes[2]: 319.36±143.50, mean±std shapes[3]: 361.93±141.42, padded_size: (128, 3, 593, 599), loop: 3013.71ms, nt:  627.53ms, padded:  897.62ms, speedup: 4.80x
```

Branch
```
model_name:   resnext101_32x4d, bsz:  16, mean±std shapes[2]: 256.75±135.80, mean±std shapes[3]: 370.56±148.10, padded_size: (16, 3, 561, 563), loop:  354.78ms, nt:   88.54ms, padded:  113.13ms, speedup: 4.01x
model_name:   resnext101_32x4d, bsz:  32, mean±std shapes[2]: 304.19±155.05, mean±std shapes[3]: 330.72±145.72, padded_size: (32, 3, 566, 564), loop:  722.01ms, nt:  146.96ms, padded:  199.63ms, speedup: 4.91x
model_name:   resnext101_32x4d, bsz:  64, mean±std shapes[2]: 323.17±145.32, mean±std shapes[3]: 363.86±141.50, padded_size: (64, 3, 567, 591), loop: 1443.90ms, nt:  298.10ms, padded:  409.83ms, speedup: 4.84x
model_name:   resnext101_32x4d, bsz: 128, mean±std shapes[2]: 319.36±143.50, mean±std shapes[3]: 361.93±141.42, padded_size: (128, 3, 593, 599), loop: 2902.21ms, nt:  605.66ms, padded:  899.02ms, speedup: 4.79x
```