### PR TITLE
fix ignored constant return value in EfficientSizeNode

### DIFF
--- a/nestedtensor/csrc/storage/EfficientSizeNode.h
+++ b/nestedtensor/csrc/storage/EfficientSizeNode.h
@@ -104,7 +104,7 @@ struct EfficientSizeNode {
   const at::Tensor& sizes() const {
     return _sizes;
   }
-  const int64_t structure() const {
+  int64_t structure() const {
     return _structure;
   }
   EfficientSizeNode clone() const {


### PR DESCRIPTION
Summary: nvcc fires off a warning about this, and more than zero build configurations turn that warning into an error, and this is unnecessary anyway so let's just fix it.

Differential Revision: D34307229

