### PR TITLE
Avoid tuple_map in nested_node.h

### DIFF
--- a/nestedtensor/csrc/storage/EfficientSizeNode.h
+++ b/nestedtensor/csrc/storage/EfficientSizeNode.h
@@ -104,7 +104,7 @@ struct EfficientSizeNode {
   const at::Tensor& sizes() const {
     return _sizes;
   }
-  const int64_t structure() const {
+  int64_t structure() const {
     return _structure;
   }
   EfficientSizeNode clone() const {


### PR DESCRIPTION
Summary: This caused build problems with c10::guts::apply calling a `__host__` function from a `__host__` `__device__` function for me. This version is likely more efficient anyway because it doesn't copy `NestedNode`, which contains `std::vector`.

Differential Revision: D34307227

